### PR TITLE
Add WSL section in install-guide.md

### DIFF
--- a/container-toolkit/install-guide.md
+++ b/container-toolkit/install-guide.md
@@ -114,11 +114,24 @@ backlinks: none
    The `nvidia-ctk` command modifies the `/etc/docker/daemon.json` file on the host.
    The file is updated so that Docker can use the NVIDIA Container Runtime.
 
-1. Restart the Docker daemon:
+2. Restart the Docker daemon:
 
    ```console
    $ sudo systemctl restart docker
    ```
+
+#### On WSL
+
+With docker installed on windows running with the WSL backend the container runtime for Docker can be configured as
+ 
+1. Configure the container runtime by using the `nvidia-ctk` command:
+   ```console
+   $ sudo nvidia-ctk runtime configure --runtime=docker --config /mnt/<windows drive>/Users/<your user>/.docker/daemon.json
+   ```
+   
+   If your daemon configuration on windows is locate elsewhere the `--config` argument should be updated accordingly.
+   
+2. Restart the Docker daemon from windows
 
 #### Rootless mode
 


### PR DESCRIPTION
A small addition to the documentation of the container toolkit. After having struggled a bit to get the nvidia runtime to work for docker on windows with WSL, where WSL is used as backend following these [docker instructions](https://docs.docker.com/desktop/gpu/) and this [container-toolkit installation guide](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/install-guide.html#installing-the-nvidia-container-toolkit) I figured out that the only change needed was to specify the daemon config file in the windows system. Thus, it would have helped me and will maybe help other to add to the following WSL instructions to the configuring docker subsection

Thanks and kind regards
Signed-off-by: Daniel Andreasen <akda@aarhus.dk>
