### PR TITLE
VM passthrough can be default sandbox workload

### DIFF
--- a/gpu-operator/getting-started.rst
+++ b/gpu-operator/getting-started.rst
@@ -232,6 +232,13 @@ These options can be used with ``--set`` when installing with Helm.
      - The GPU operator deploys ``PodSecurityPolicies`` if enabled.
      - ``false``
 
+   * - ``sandboxWorkloads.defaultWorkload``
+     - Specifies the default type of workload for the cluster, one of ``container``, ``vm-passthrough``, or ``vm-vgpu``.
+       
+       Setting ``vm-passthrough`` or ``vm-vgpu`` can be helpful if you plan to run all or mostly virtual machines in your cluster.
+       Refer to :doc:`KubeVirt <gpu-operator-kubevirt>`, :doc:`Kata Containers <gpu-operator-kata>`, or :doc:`Confidential Containers <gpu-operator-confidential-containers>`.
+     - ``container``
+
    * - ``toolkit.enabled``
      - By default, the Operator deploys the NVIDIA Container Toolkit (``nvidia-docker2`` stack)
        as a container on the system. Set this value to ``false`` when using the Operator on systems

--- a/gpu-operator/gpu-operator-confidential-containers.rst
+++ b/gpu-operator/gpu-operator-confidential-containers.rst
@@ -247,7 +247,7 @@ Installing and configuring your cluster to support the NVIDIA GPU Operator with 
 #. Label the worker nodes that you want to use with confidential containers.
 
    This step ensures that you can continue to run traditional container workloads with GPU or vGPU workloads on some nodes in your cluster.
-   Alternatively, you can set the default sandbox workload to ``vm-passthrough`` to run confidential containers on all worker nodes.
+   Alternatively, you can set the default sandbox workload to ``vm-passthrough`` to run confidential containers on all worker nodes when you install the GPU Operator.
 
 #. Install the Confidential Containers Operator.
 
@@ -275,13 +275,6 @@ Perform the following steps to install and verify the Confidential Containers Op
    .. code-block:: console
 
       $ kubectl label node <node-name> nvidia.com/gpu.workload.config=vm-passthrough
-
-   Alternatively, set the default sandbox workload to ``vm-passthrough`` to run |project-name| on all worker nodes:
-
-   .. code-block:: console
-
-      $ kubectl patch clusterpolicies.nvidia.com/cluster-policy --type='json' \
-          -p='[{"op": "replace", "path": "/spec/sandboxWorkloads/defaultWorkload", "value": "vm-passthrough"}]'
 
 #. Set the Operator version in an environment variable:
 
@@ -406,7 +399,8 @@ Perform the following steps to install the Operator for use with confidential co
          && helm repo update
 
 
-#. Specify at least the following options when you install the Operator:
+#. Specify at least the following options when you install the Operator.
+   If you want to run |project-name| by default on all worker nodes, also specify ``--set sandboxWorkloads.defaultWorkload=vm-passthough``.
 
    .. code-block:: console
 
@@ -417,6 +411,7 @@ Perform the following steps to install the Operator for use with confidential co
          --set kataManager.enabled=true \
          --set ccManager.enabled=true \
          --set nfd.nodefeaturerules=true
+
 
    *Example Output*
 

--- a/gpu-operator/gpu-operator-confidential-containers.rst
+++ b/gpu-operator/gpu-operator-confidential-containers.rst
@@ -247,6 +247,7 @@ Installing and configuring your cluster to support the NVIDIA GPU Operator with 
 #. Label the worker nodes that you want to use with confidential containers.
 
    This step ensures that you can continue to run traditional container workloads with GPU or vGPU workloads on some nodes in your cluster.
+   Alternatively, you can set the default sandbox workload to ``vm-passthrough`` to run confidential containers on all worker nodes.
 
 #. Install the Confidential Containers Operator.
 
@@ -274,6 +275,13 @@ Perform the following steps to install and verify the Confidential Containers Op
    .. code-block:: console
 
       $ kubectl label node <node-name> nvidia.com/gpu.workload.config=vm-passthrough
+
+   Alternatively, set the default sandbox workload to ``vm-passthrough`` to run |project-name| on all worker nodes:
+
+   .. code-block:: console
+
+      $ kubectl patch clusterpolicies.nvidia.com/cluster-policy --type='json' \
+          -p='[{"op": "replace", "path": "/spec/sandboxWorkloads/defaultWorkload", "value": "vm-passthrough"}]'
 
 #. Set the Operator version in an environment variable:
 
@@ -305,7 +313,7 @@ Perform the following steps to install and verify the Confidential Containers Op
       service/cc-operator-controller-manager-metrics-service created
       deployment.apps/cc-operator-controller-manager create
 
-#. (Optional) View the pods and services in the ``confidential-containers-system`` namespace:
+#. Optional: View the pods and services in the ``confidential-containers-system`` namespace:
 
    .. code-block:: console
 
@@ -360,7 +368,7 @@ Perform the following steps to install and verify the Confidential Containers Op
 
    Wait a few minutes for the Operator to create the base runtime classes.
 
-#. (Optional) View the runtime classes:
+#. Optional: View the runtime classes:
 
    .. code-block:: console
 

--- a/gpu-operator/gpu-operator-kata.rst
+++ b/gpu-operator/gpu-operator-kata.rst
@@ -226,6 +226,7 @@ Installing and configuring your cluster to support the NVIDIA GPU Operator with 
 #. Label the worker nodes that you want to use with Kata Containers.
 
    This step ensures that you can continue to run traditional container workloads with GPU or vGPU workloads on some nodes in your cluster.
+   Alternatively, you can set the default sandbox workload to ``vm-passthrough`` to run confidential containers on all worker nodes.
 
 #. Install the Confidential Containers Operator.
 

--- a/gpu-operator/gpu-operator-kata.rst
+++ b/gpu-operator/gpu-operator-kata.rst
@@ -261,7 +261,8 @@ Perform the following steps to install the Operator for use with Kata Containers
       $ helm repo add nvidia https://helm.ngc.nvidia.com/nvidia \
          && helm repo update
 
-#. Specify at least the following options when you install the Operator:
+#. Specify at least the following options when you install the Operator.
+   If you want to run |project-name| by default on all worker nodes, also specify ``--set sandboxWorkloads.defaultWorkload=vm-passthough``.
 
    .. code-block:: console
 


### PR DESCRIPTION
Fixes #41.

Mention in [Overview of Installation and Configuration](https://nvidia.github.io/cloud-native-docs/review/pr-42/gpu-operator/latest/gpu-operator-kata.html#overview-of-installation-and-configuration) that a default is possible.

First step of the [Install](https://nvidia.github.io/cloud-native-docs/review/pr-42/gpu-operator/latest/gpu-operator-kata.html#install-the-confidential-containers-operator) procedure shows the `kubectl patch` command to set a default sandbox workload.