### PR TITLE
Link to correct container toolkit repo

### DIFF
--- a/gpu-operator/overview.rst
+++ b/gpu-operator/overview.rst
@@ -30,7 +30,7 @@ However, configuring and managing nodes with these hardware resources requires
 configuration of multiple software components such as drivers, container runtimes or other libraries which are difficult
 and prone to errors. The NVIDIA GPU Operator uses the `operator framework <https://coreos.com/blog/introducing-operator-framework>`_
 within Kubernetes to automate the management of all NVIDIA software components needed to provision GPU. These components include the NVIDIA drivers (to enable CUDA),
-Kubernetes device plugin for GPUs, the `NVIDIA Container Toolkit <https://github.com/NVIDIA/nvidia-docker>`_,
+Kubernetes device plugin for GPUs, the `NVIDIA Container Toolkit <https://github.com/NVIDIA/nvidia-container-toolkit>`_,
 automatic node labelling using `GFD <https://github.com/NVIDIA/gpu-feature-discovery>`_, `DCGM <https://developer.nvidia.com/dcgm>`_ based monitoring and others.
 
 ----

--- a/openshift/introduction.rst
+++ b/openshift/introduction.rst
@@ -12,7 +12,7 @@ Red Hat OpenShift Container Platform is a security-centric and enterprise-grade 
 Red Hat OpenShift Container Platform includes enhancements to Kubernetes so users can easily configure and use GPU resources for accelerating workloads such as deep learning.
 
 The NVIDIA GPU Operator uses the operator framework within Kubernetes to automate the management of all NVIDIA software components needed to provision GPU. These components include the NVIDIA drivers (to enable CUDA),
-Kubernetes device plugin for GPUs, the `NVIDIA Container Toolkit <https://github.com/NVIDIA/nvidia-docker>`_,
+Kubernetes device plugin for GPUs, the `NVIDIA Container Toolkit <https://github.com/NVIDIA/nvidia-container-toolkit>`_,
 automatic node labelling using `GFD <https://github.com/NVIDIA/gpu-feature-discovery>`_, `DCGM <https://developer.nvidia.com/dcgm>`_ based monitoring and others.
 
 For guidance on the specific NVIDIA support entitlement needs, see `obtaining support from NVIDIA <https://access.redhat.com/solutions/5174941>`_.

--- a/playground/dind.rst
+++ b/playground/dind.rst
@@ -82,5 +82,5 @@ Or launch an interactive session within an interactive session, Inception style!
    |  No running processes found                                                 |
    +-----------------------------------------------------------------------------+
 
-What other cool stuff can you do? Send us details via GitHub `issues <https://github.com/NVIDIA/nvidia-docker/issues>`_! 
+What other cool stuff can you do? Send us details via GitHub `issues <https://github.com/NVIDIA/nvidia-container-toolkit/issues>`_! 
 


### PR DESCRIPTION
The `nvidia-docker` project is superseded by`nvidia-container-toolkit`. Update links to point at the new repo.