### PR TITLE
remove redundant link in Next Steps section of vgpu page

### DIFF
--- a/gpu-operator/install-gpu-operator-vgpu.rst
+++ b/gpu-operator/install-gpu-operator-vgpu.rst
@@ -290,4 +290,3 @@ Next Steps
 **********
 
 - :ref:`verify gpu operator install`
-- :ref:`running sample gpu applications`


### PR DESCRIPTION
<img width="727" alt="Screenshot 2024-08-13 at 11 36 54 AM" src="https://github.com/user-attachments/assets/e120d2c4-4e9e-47ce-af99-b1c39fcc6503">
