### PR TITLE
Add banner for security update

### DIFF
--- a/templates/breadcrumbs.html
+++ b/templates/breadcrumbs.html
@@ -5,8 +5,8 @@
 
 {%- block breadcrumbs %}
 <div> <!-- class="omni-version-warning" -->
-  <p class="omni-version-warning-content"> Upgrade to NVIDIA Container Toolkit v1.16.2 or GPU Operator v24.6.2 to install a critical security update.
-  </p>
+  <p class="omni-version-warning-content"> Upgrade to NVIDIA Container Toolkit v1.16.2 or GPU Operator v24.6.2 to install a critical security update.<br/>
+  Refer to <a href="https://nvidia.custhelp.com/app/answers/detail/a_id/5582">Security Bulletin: NVIDIA Container Toolkit - September 2024</a> for more information.</p>
 </div>
 
 <li>

--- a/templates/breadcrumbs.html
+++ b/templates/breadcrumbs.html
@@ -4,6 +4,11 @@
 {% set cloud_native_home = docs_home + "/datacenter/cloud-native/" %}
 
 {%- block breadcrumbs %}
+<div> <!-- class="omni-version-warning" -->
+  <p class="omni-version-warning-content"> Upgrade to NVIDIA Container Toolkit v1.16.2 or GPU Operator v24.6.2 to install a critical security update.
+  </p>
+</div>
+
 <li>
     <a href="{{ docs_home }}">NVIDIA Docs Hub</a>
     <i class="fa fa-chevron-right" aria-hidden="true"></i>


### PR DESCRIPTION
Review HTML:
- toolkit: https://nvidia.github.io/cloud-native-docs/review/pr-110/container-toolkit/latest/index.html
- gpu-op: https://nvidia.github.io/cloud-native-docs/review/pr-110/gpu-operator/latest/index.html
- ocp: https://nvidia.github.io/cloud-native-docs/review/pr-110/openshift/latest/index.html

My only uncertainty is how this banner might interact with a "version selector" warning when someone selects an older version of the docs.

@francisguillier, @cdesiniotis, @elezar, PTAL.