### PR TITLE
Update BM and VMs to OCP 4.17

### DIFF
--- a/gpu-operator/platform-support.rst
+++ b/gpu-operator/platform-support.rst
@@ -451,7 +451,7 @@ Operating System    Kubernetes           KubeVirt              OpenShift Virtual
 ================    ===========   =============   =========    =============    ===========
 Ubuntu 20.04 LTS    1.23---1.29   0.36+           0.59.1+
 Ubuntu 22.04 LTS    1.23---1.29   0.36+           0.59.1+
-Red Hat Core OS                                                4.12---4.16      4.13---4.16
+Red Hat Core OS                                                4.12---4.17      4.13---4.17
 ================    ===========   =============   =========    =============    ===========
 
 You can run GPU passthrough and NVIDIA vGPU in the same cluster as long as you use

--- a/gpu-operator/platform-support.rst
+++ b/gpu-operator/platform-support.rst
@@ -303,7 +303,7 @@ The GPU Operator has been validated in the following scenarios:
 
        * - Red Hat Core OS
          -
-         - | 4.12---4.16
+         - | 4.12---4.17
          -
          -
          -
@@ -400,7 +400,7 @@ The GPU Operator has been validated in the following scenarios:
 
        * - Red Hat Core OS
          -
-         - 4.12---4.16
+         - 4.12---4.17
          -
          -
 


### PR DESCRIPTION
@francisguillier, PTAL.  Is this table the only update?  

https://nvidia.github.io/cloud-native-docs/review/pr-114/gpu-operator/latest/platform-support.html#supported-operating-systems-and-kubernetes-platforms

We don't update the table a little further down for virtualization?

https://nvidia.github.io/cloud-native-docs/review/pr-114/gpu-operator/latest/platform-support.html#support-for-kubevirt-and-openshift-virtualization

TY!