### PR TITLE
Specify namespace when getting GPU driver upgrade events

### DIFF
--- a/gpu-operator/gpu-driver-upgrades.rst
+++ b/gpu-operator/gpu-driver-upgrades.rst
@@ -219,7 +219,7 @@ Below are an example set of events generated for the upgrade of one node.
 
 .. code-block:: console
 
-   $ kubectl get events --sort-by='.lastTimestamp' | grep GPUDriverUpgrade
+   $ kubectl get events -n default --sort-by='.lastTimestamp' | grep GPUDriverUpgrade
 
 *Example Output*
 
@@ -259,7 +259,7 @@ If the upgrade fails for a particular node, the node is labelled with the ``upgr
 
    .. code:: console
 
-      $ kubectl get events --sort-by='.lastTimestamp' | grep GPUDriverUpgrade
+      $ kubectl get events -n default --sort-by='.lastTimestamp' | grep GPUDriverUpgrade
 
 #. (Optional) Check the logs from the upgrade controller in the gpu-operator container:
 


### PR DESCRIPTION
Events are namespace-scoped. The GPUDriverUpgrade events are associated with Node objects and are emitted in the default namespace. This aligns with the Node events generated by the kubelet, which also show up in the default namespace.