### PR TITLE
toolkit: install guide: refer to section about supported platforms, tweak headings

### DIFF
--- a/container-toolkit/install-guide.md
+++ b/container-toolkit/install-guide.md
@@ -10,14 +10,14 @@
 
 ### Prerequisites
 
-Install the NVIDIA GPU driver for your Linux distribution.
+1. Install the NVIDIA GPU driver for your Linux distribution.
 NVIDIA recommends installing the driver by using the package manager for your distribution.
-
 For information about installing the driver with a package manager, refer to
 the [_NVIDIA Driver Installation Quickstart Guide_](https://docs.nvidia.com/datacenter/tesla/tesla-installation-notes/index.html).
+Alternatively, you can install the driver by [downloading](https://www.nvidia.com/en-us/drivers/) a `.run` installer.
 
-Alternatively, you can install the driver by downloading a `.run` installer.
-Refer to the NVIDIA [Official Drivers](https://www.nvidia.com/Download/index.aspx?lang=en-us) page.
+
+2. Read [this section](./supported-platforms.md) about platform support.
 
 ### Debian-based distributions (Ubuntu):
 

--- a/container-toolkit/install-guide.md
+++ b/container-toolkit/install-guide.md
@@ -103,11 +103,6 @@ Alternatively, you can install the driver by [downloading](https://www.nvidia.co
    $ sudo zypper modifyrepo --enable nvidia-container-toolkit-experimental
    ```
 
-   <!--
-   TODO:
-   - [ ] Experimental repos: zypper modifyrepo --enable nvidia-container-toolkit-experimental
-   -->
-
 1. Install the NVIDIA Container Toolkit packages:
 
    ```console

--- a/container-toolkit/install-guide.md
+++ b/container-toolkit/install-guide.md
@@ -19,7 +19,7 @@ the [_NVIDIA Driver Installation Quickstart Guide_](https://docs.nvidia.com/data
 Alternatively, you can install the driver by downloading a `.run` installer.
 Refer to the NVIDIA [Official Drivers](https://www.nvidia.com/Download/index.aspx?lang=en-us) page.
 
-### Installing with Apt
+### Debian-based distributions (Ubuntu):
 
 1. Configure the production repository:
 
@@ -53,7 +53,7 @@ Refer to the NVIDIA [Official Drivers](https://www.nvidia.com/Download/index.asp
    $ sudo apt-get install -y nvidia-container-toolkit
    ```
 
-### Installing with Yum or Dnf
+### RPM-based distributions (RHEL/CentOS, Fedora, Amazon Linux, ...):
 
 1. Configure the production repository:
 
@@ -74,7 +74,7 @@ Refer to the NVIDIA [Official Drivers](https://www.nvidia.com/Download/index.asp
    $ sudo yum install -y nvidia-container-toolkit
    ```
 
-### Installing with Zypper
+### OpenSUSE/SLE:
 
 1. Configure the production repository:
 

--- a/container-toolkit/install-guide.md
+++ b/container-toolkit/install-guide.md
@@ -4,7 +4,6 @@
 
 # Installing the NVIDIA Container Toolkit
 
-
 ## Installation
 
 (pre-requisites)=
@@ -19,6 +18,8 @@ For information about installing the driver with a package manager, refer to
 the [_NVIDIA Driver Installation Quickstart Guide_](https://docs.nvidia.com/datacenter/tesla/tesla-installation-notes/index.html).
 Alternatively, you can install the driver by [downloading](https://www.nvidia.com/en-us/drivers/) a `.run` installer.
 
+
+(installing-with-apt)=
 
 ### With `apt`: Ubuntu, Debian
 
@@ -58,6 +59,8 @@ Alternatively, you can install the driver by [downloading](https://www.nvidia.co
    $ sudo apt-get install -y nvidia-container-toolkit
    ```
 
+(installing-with-yum-or-dnf)=
+
 ### With `dnf`: RHEL/CentOS, Fedora, Amazon Linux
 
 
@@ -83,6 +86,8 @@ Alternatively, you can install the driver by [downloading](https://www.nvidia.co
    ```console
    $ sudo dnf install -y nvidia-container-toolkit
    ```
+
+(installing-with-zypper)=
 
 ### With `zypper`: OpenSUSE, SLE
 

--- a/container-toolkit/install-guide.md
+++ b/container-toolkit/install-guide.md
@@ -20,7 +20,11 @@ the [_NVIDIA Driver Installation Quickstart Guide_](https://docs.nvidia.com/data
 Alternatively, you can install the driver by [downloading](https://www.nvidia.com/en-us/drivers/) a `.run` installer.
 
 
-### Ubuntu and Debian
+### With `apt`: Ubuntu, Debian
+
+   ```{note}
+   These instructions [should work](./supported-platforms.md) for any Debian-derived distribution.
+   ```
 
 1. Configure the production repository:
 
@@ -54,7 +58,12 @@ Alternatively, you can install the driver by [downloading](https://www.nvidia.co
    $ sudo apt-get install -y nvidia-container-toolkit
    ```
 
-### RHEL/CentOS, Fedora, Amazon Linux
+### With `dnf`: RHEL/CentOS, Fedora, Amazon Linux
+
+
+   ```{note}
+   These instructions [should work](./supported-platforms.md) for many RPM-based distributions.
+   ```
 
 1. Configure the production repository:
 
@@ -66,16 +75,16 @@ Alternatively, you can install the driver by [downloading](https://www.nvidia.co
    Optionally, configure the repository to use experimental packages:
 
    ```console
-   $ sudo yum-config-manager --enable nvidia-container-toolkit-experimental
+   $ sudo dnf-config-manager --enable nvidia-container-toolkit-experimental
    ```
 
 1. Install the NVIDIA Container Toolkit packages:
 
    ```console
-   $ sudo yum install -y nvidia-container-toolkit
+   $ sudo dnf install -y nvidia-container-toolkit
    ```
 
-### OpenSUSE, SLE
+### With `zypper`: OpenSUSE, SLE
 
 1. Configure the production repository:
 

--- a/container-toolkit/install-guide.md
+++ b/container-toolkit/install-guide.md
@@ -4,22 +4,23 @@
 
 # Installing the NVIDIA Container Toolkit
 
+
 ## Installation
 
 (pre-requisites)=
 
 ### Prerequisites
 
-1. Install the NVIDIA GPU driver for your Linux distribution.
+1. Read [this section](./supported-platforms.md) about platform support.
+
+2. Install the NVIDIA GPU driver for your Linux distribution.
 NVIDIA recommends installing the driver by using the package manager for your distribution.
 For information about installing the driver with a package manager, refer to
 the [_NVIDIA Driver Installation Quickstart Guide_](https://docs.nvidia.com/datacenter/tesla/tesla-installation-notes/index.html).
 Alternatively, you can install the driver by [downloading](https://www.nvidia.com/en-us/drivers/) a `.run` installer.
 
 
-2. Read [this section](./supported-platforms.md) about platform support.
-
-### Debian-based distributions (Ubuntu):
+### Ubuntu and other Debian-based distributions
 
 1. Configure the production repository:
 
@@ -53,7 +54,7 @@ Alternatively, you can install the driver by [downloading](https://www.nvidia.co
    $ sudo apt-get install -y nvidia-container-toolkit
    ```
 
-### RPM-based distributions (RHEL/CentOS, Fedora, Amazon Linux, ...):
+### RHEL/CentOS, Fedora, Amazon Linux, ... :
 
 1. Configure the production repository:
 
@@ -74,7 +75,7 @@ Alternatively, you can install the driver by [downloading](https://www.nvidia.co
    $ sudo yum install -y nvidia-container-toolkit
    ```
 
-### OpenSUSE/SLE:
+### OpenSUSE, SLE:
 
 1. Configure the production repository:
 

--- a/container-toolkit/install-guide.md
+++ b/container-toolkit/install-guide.md
@@ -20,7 +20,7 @@ the [_NVIDIA Driver Installation Quickstart Guide_](https://docs.nvidia.com/data
 Alternatively, you can install the driver by [downloading](https://www.nvidia.com/en-us/drivers/) a `.run` installer.
 
 
-### Ubuntu and other Debian-based distributions
+### Ubuntu and Debian
 
 1. Configure the production repository:
 
@@ -54,7 +54,7 @@ Alternatively, you can install the driver by [downloading](https://www.nvidia.co
    $ sudo apt-get install -y nvidia-container-toolkit
    ```
 
-### RHEL/CentOS, Fedora, Amazon Linux, ... :
+### RHEL/CentOS, Fedora, Amazon Linux
 
 1. Configure the production repository:
 
@@ -75,7 +75,7 @@ Alternatively, you can install the driver by [downloading](https://www.nvidia.co
    $ sudo yum install -y nvidia-container-toolkit
    ```
 
-### OpenSUSE, SLE:
+### OpenSUSE, SLE
 
 1. Configure the production repository:
 


### PR DESCRIPTION
I find it important that the installation section informs about supported platforms. We have a section for that (in a different doc) so all we are missing is a cross-reference. 

Is Sphinx our documentation generator? I think / hope that cross-references in md-sphinx work as I am trying here, but I did not test this locally.

Also tweaking the headings to shift attention to the distribution names more than the tooling.