### PR TITLE
toolkit: supported platforms: note that things may work on other/newer distros

### DIFF
--- a/container-toolkit/supported-platforms.md
+++ b/container-toolkit/supported-platforms.md
@@ -4,29 +4,39 @@
 
 (supported-platforms)=
 
-# Supported Platforms
+# Platform support
+
+Recent NVIDIA Container Toolkit releases are tested and expected to work on these Linux distributions:
+
+| OS Name / Version        | amd64 / x86_64 | ppc64le | arm64 / aarch64 {sup}`1` |
+| ------------------------ | -------------- | ------- | ------------------------ |
+| Amazon Linux 2023        | X              |         | X {sup}`2`               |
+| Amazon Linux 2           | X              |         | X                        |
+| Open Suse/SLES 15.x      | X              |         |                          |
+| Debian Linux 11          | X              |         |                          |
+| CentOS 8                 | X              | X       | X                        |
+| RHEL 8.x                 | X              | X       | X                        |
+| RHEL 9.x                 | X              | X       | X                        |
+| Ubuntu 20.04             | X              | X       | X                        |
+| Ubuntu 22.04             | X              | X       | X                        |
+| Ubuntu 24.04             | X              |         | X                        |
 
 
-## Linux Distributions
+## Please report issues
 
-Supported Linux distributions are listed below:
+Our qualification-testing procedures are constantly evolving and we might miss
+certain problems. Please
+[report](https://github.com/NVIDIA/nvidia-container-toolkit/issues) issues in
+particular as they occur on a platform listed above.
 
-| OS Name / Version        | amd64 / x86_64 | ppc64le | arm64 / aarch64 |
-| ------------------------ | -------------- | ------- | --------------- |
-| Amazon Linux 2023        | X              |         | X {sup}`1`      |
-| Amazon Linux 2           | X              |         | X               |
-| Open Suse/SLES 15.x      | X              |         |                 |
-| Debian Linux 11          | X              |         |                 |
-| Centos 8                 | X              | X       | X               |
-| RHEL 8.x                 | X              | X       | X               |
-| RHEL 9.x                 | X              | X       | X               |
-| Ubuntu 20.04             | X              | X       | X               |
-| Ubuntu 22.04             | X              | X       | X               |
-| Ubuntu 24.04             | X              |         | X               |
 
-The `arm64` / `aarch64` architecture includes support for Tegra-based systems.
+## Other Linux distributions
 
-1. For Amazon Linux 2023 on Arm64, a `g5g.2xlarge` Amazon EC2 instance was used for validation.
+Releases may work on more platforms than indicated in the table above (e.g., on distribution versions older and newer than listed).
+Give things a try and we invite you to [report](https://github.com/NVIDIA/nvidia-container-toolkit/issues) any issue observed even if your Linux distribution is not listed.
+
+----
+
+1. The `arm64` / `aarch64` architecture includes support for Tegra-based systems.
+2. For Amazon Linux 2023 on Arm64, a `g5g.2xlarge` Amazon EC2 instance was used for validation.
    The `g5g.xlarge` instance caused failures due to the limited system memory.
-
-


### PR DESCRIPTION
I was reading through the discussion in https://github.com/NVIDIA/cloud-native-docs/pull/62 and found it very tangible. Instead of iterating on the PR I thought I create a new one with my proposal to address some of the points discussed there.

I very much agree with @elezar that we need a note about those distributions that are _not_ listed in that table, and that we want to invite people to just try things out. This is the main part of this patch.

Additional changes:

- Centos -> CentOS
- Instead of loading lots of meaning into a single word: ["supported" vs "qualified"](https://github.com/NVIDIA/cloud-native-docs/pull/62#discussion_r1606776018) I propose using slightly more exhaustive wording: "qualification-tested and expected to work on these platforms"
- We did use footnotes, and I have changed one note about Tegra into a footnote.

