### PR TITLE
chore: Add Adobe analytics scripts to docs

### DIFF
--- a/repo.toml
+++ b/repo.toml
@@ -10,6 +10,18 @@ favicon = "${root}/assets/favicon.ico"
 logo = "${root}/assets/nvidia-logo-white.png"
 author = "NVIDIA Corporation"
 
+extra_content_head = [
+  '''
+  <script src="https://assets.adobedtm.com/5d4962a43b79/c1061d2c5e7b/launch-191c2462b890.min.js" ></script>
+  ''',
+]
+
+extra_content_footer = [
+  '''
+  <script type="text/javascript">if (typeof _satellite !== "undefined") {_satellite.pageBottom();}</script>
+  ''',
+]
+
 sphinx_conf_py_extra = """
   myst_enable_extensions = [
     "colon_fence", "dollarmath",


### PR DESCRIPTION
Repo docs was sufficiently new to support the two options.

Snippet from container toolkit:

![image](https://github.com/user-attachments/assets/32cd2562-1c66-44d5-8eb3-869fbc38b429)