### PR TITLE
update vgpu and gpu pass through example in gpu/openshift docs

### DIFF
--- a/gpu-operator/gpu-operator-kubevirt.rst
+++ b/gpu-operator/gpu-operator-kubevirt.rst
@@ -224,7 +224,9 @@ The following example shows how to permit the A10 GPU device and A10-24Q vGPU de
                 Subsystem: NVIDIA Corporation GA102GL [A10] [10de:1482]
                 Kernel modules: nvidiafb, nouveau
 
-#. Modify the ``KubeVirt`` custom resource like the following partial example:
+#. Modify the ``KubeVirt`` custom resource like the following partial example. 
+
+   Add 
 
    .. code-block:: yaml
 
@@ -235,12 +237,12 @@ The following example shows how to permit the A10 GPU device and A10-24Q vGPU de
             featureGates:
             - GPU
             - DisableMDEVConfiguration
-          permittedHostDevices:
-            pciHostDevices:
+          permittedHostDevices: # Defines VM devices to import.
+            pciHostDevices: # Include for GPU passthrough
             - externalResourceProvider: true
               pciVendorSelector: 10DE:2236
               resourceName: nvidia.com/GA102GL_A10
-            mediatedDevices:
+            mediatedDevices: # Include for vGPU 
             - externalResourceProvider: true
               mdevNameSelector: NVIDIA A10-24Q
               resourceName: nvidia.com/NVIDIA_A10-24Q
@@ -248,7 +250,11 @@ The following example shows how to permit the A10 GPU device and A10-24Q vGPU de
 
    Replace the values in the YAML as follows:
 
-   * ``pciDeviceSelector`` and ``resourceName`` under ``pciHostDevices`` to correspond to your GPU model.
+   * Include ``permittedHostDevices`` for GPU passthrough.
+
+   * Include ``mediatedDevices`` for vGPU.
+
+   * ``pciVendorSelector`` and ``resourceName`` under ``pciHostDevices`` to correspond to your GPU model.
 
    * ``mdevNameSelector`` and ``resourceName`` under ``mediatedDevices`` to correspond to your vGPU type.
 

--- a/openshift/openshift-virtualization.rst
+++ b/openshift/openshift-virtualization.rst
@@ -370,18 +370,22 @@ The following example permits the A10 GPU device and A10-24Q vGPU device.
       spec:
         featureGates:
           disableMDevConfiguration: true
-        permittedHostDevices:
-          pciHostDevices:
+        permittedHostDevices: # Defines VM devices to import.
+          pciHostDevices: # Include for GPU passthrough
           - externalResourceProvider: true
             pciDeviceSelector: 10DE:2236
             resourceName: nvidia.com/GA102GL_A10
-          mediatedDevices:
+          mediatedDevices: # Include for vGPU
           - externalResourceProvider: true
             mdevNameSelector: NVIDIA A10-24Q
             resourceName: nvidia.com/NVIDIA_A10-24Q
       ...
 
    Replace the values in the YAML as follows:
+
+   * Include ``permittedHostDevices`` for GPU passthrough.
+
+   * Include ``mediatedDevices`` for vGPU.
 
    * ``pciDeviceSelector`` and ``resourceName`` under ``pciHostDevices`` to correspond to your GPU model.
 


### PR DESCRIPTION
Added in notes to the YAML example to clarify that some sections are required for vGPU and GPU passthrough use cases. I think this helps to add clarity for how to use the sample. Some feedback was to fully split out the sample into different yaml examples.

Are users likely to want to use both at the same time? Or is it more likely that users are doing one path over the other?