### PR TITLE
chore: Update theme dependencies

### DIFF
--- a/.github/workflows/docs-build.yaml
+++ b/.github/workflows/docs-build.yaml
@@ -10,7 +10,7 @@ on:
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}
-  TAG: 0.4.0
+  TAG: 0.5.0
   GH_TOKEN: ${{ github.token }}
 
 concurrency:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,7 +1,7 @@
 variables:
   CONTAINER_TEST_IMAGE: "${CI_REGISTRY_IMAGE}:${CI_COMMIT_REF_SLUG}"
   CONTAINER_RELEASE_IMAGE: "${CI_REGISTRY_IMAGE}:0.5.0"
-  BUILDER_IMAGE: ghcr.io/nvidia/cloud-native-docs:0.4.0
+  BUILDER_IMAGE: ghcr.io/nvidia/cloud-native-docs:0.5.0
   PUBLISHER_IMAGE: "${CI_REGISTRY_PUBLISHER}/publisher:3.1.0"
 
 stages:

--- a/README.md
+++ b/README.md
@@ -169,6 +169,27 @@ If the commit message includes `/not-latest`, then only the documentation in the
 
 <https://docs.nvidia.com/datacenter/cloud-native/gpu-operator/23.3.1/index.html>
 
+## Updating Dependencies
+
+1. Make an update to `docker/Dockerfile` to specify the dependency change.
+
+1. Update `.github/workflows/docs-build.yaml` and increment the `env.TAG` value.
+
+1. Update `.gitlab-ci.yml` and set the same value--prefixed by `ghcr.io...`--in the `variables.BUILDER_IMAGE` field.
+
+1. Optional: [Build the container and docs](#building-the-container) locally and confirm the update works as intended.
+
+1. Open a pull request.
+
+   The pull request builds a commit-specific container and builds the docs from that container.
+   Review the preview HTML to confirm the update works as intended.
+
+1. After you merge the pull request, the `docs-build.yaml` action detects that the newly incremented `env.TAG`
+   container is not in the registry, builds the container with that tag and pushes it to the GitHub registry.
+
+   When you tag a commit to publish, GitLab CI pulls image from the `variables.BUILDER_IMAGE` value,
+   builds the documentation, and that HTML is delivered to docs.nvidia.com.
+
 ## License and Contributing
 
 This documentation repository is licensed under [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0).

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -23,5 +23,5 @@ RUN --mount=type=bind,source=.,destination=/x,rw /x/tools/packman/python.sh -m p
    nvidia-sphinx-theme \
    pydata-sphinx-theme
 
- RUN (cd /tmp/extension; tar cf - . ) | (cd /var/tmp/packman/chk/sphinx/4.5.0.2-py3.7-linux-x86_64/; tar xf -)
+RUN (cd /tmp/extension; tar cf - . ) | (cd /var/tmp/packman/chk/sphinx/4.5.0.2-py3.7-linux-x86_64/; tar xf -)
 RUN rm -rf /tmp/extension


### PR DESCRIPTION
The version for nvidia-sphinx-theme isn't pinned in the Dockerfile, so just incrementing the container tag is enough to build and store a new container.

https://nvidia.github.io/cloud-native-docs/review/pr-182/container-toolkit/latest/index.html