### PR TITLE
KubeVirt with NVIDIA vGPU is supported on devices with Linux kernel < 6.0

### DIFF
--- a/gpu-operator/platform-support.rst
+++ b/gpu-operator/platform-support.rst
@@ -508,7 +508,6 @@ Operating System    Kubernetes           KubeVirt              OpenShift Virtual
 \                   \             | GPU           vGPU         | GPU            vGPU
                                   | Passthrough                | Passthrough
 ================    ===========   =============   =========    =============    ===========
-Ubuntu 24.04 LTS    1.23---1.29   0.36+           0.59.1+
 Ubuntu 20.04 LTS    1.23---1.29   0.36+           0.59.1+
 Ubuntu 22.04 LTS    1.23---1.29   0.36+           0.59.1+
 Red Hat Core OS                                                4.12---4.18      4.13---4.18


### PR DESCRIPTION
Signed-off-by: Andrew Chen <andrewch@nvidia.com>