### PR TITLE
add different vGPU Q profiles example

### DIFF
--- a/gpu-operator/gpu-operator-kubevirt.rst
+++ b/gpu-operator/gpu-operator-kubevirt.rst
@@ -426,13 +426,13 @@ For example, you can create a **A10-4Q** and a **A10-6Q** device on same GPU by 
 
 .. code-block:: yaml
 
-   version: v1
-   vgpu-configs:
+    version: v1
+    vgpu-configs:
       custom-A10-config:
-         - devices: all
-            vgpu-devices:
-               "A10-4Q": 3
-               "A10-6Q": 2
+        - devices: all
+           vgpu-devices:
+             "A10-4Q": 3
+             "A10-6Q": 2
 
 If custom vGPU device configuration is desired, more than the default config map provides, you can create your own config map:
 

--- a/openshift/openshift-virtualization.rst
+++ b/openshift/openshift-virtualization.rst
@@ -661,13 +661,13 @@ For example, you can create a **A10-4Q** and a **A10-6Q** device on same GPU by 
 
 .. code-block:: yaml
 
-   version: v1
-   vgpu-configs:
+    version: v1
+    vgpu-configs:
       custom-A10-config:
-         - devices: all
-            vgpu-devices:
-               "A10-4Q": 3
-               "A10-6Q": 2
+        - devices: all
+           vgpu-devices:
+             "A10-4Q": 3
+             "A10-6Q": 2
 
 If custom vGPU device configuration is desired, more than the default ConfigMap provides, you can create your own ConfigMap:
 


### PR DESCRIPTION
Previews:
* https://nvidia.github.io/cloud-native-docs/review/pr-243/gpu-operator/latest/gpu-operator-kubevirt.html#vgpu-device-configuration
* https://nvidia.github.io/cloud-native-docs/review/pr-243/openshift/latest/openshift-virtualization.html#vgpu-device-configuration

Example was added to the *vGPU Device Configuration* section:
https://github.com/NVIDIA/cloud-native-docs/pull/243/files#diff-c31625e2bdd14f7bae285853425dc9b7cec4cf1c3694af52c37eb48508e9c375R424

---
You can also create different vGPU Q profiles on same GPU using vGPU Device Manager configuration.
For example, you can create a **A10-4Q** and a **A10-6Q** device on same GPU by creating a vGPU Device Manager configuration with the following content:

```
   version: v1
   vgpu-configs:
      custom-A10-config:
         - devices: all
            vgpu-devices:
              "A10-4Q": 3
              "A10-6Q": 2
```
---
Signed-off-by: Andrew Chen <andrewch@nvidia.com>