### PR TITLE
Add DSL 3.4+ req for vGPU 18.0+

### DIFF
--- a/gpu-operator/install-gpu-operator-vgpu.rst
+++ b/gpu-operator/install-gpu-operator-vgpu.rst
@@ -234,7 +234,7 @@ Configure the Cluster with the vGPU License Information and the Driver Container
 
       $ kubectl create namespace gpu-operator
 
-#. Create a ConfigMap that is named ``licensing-config`` using the ``gridd.conf`` and ``client_configuration_token.tok`` files:
+#. Create a config map that is named ``licensing-config`` using the ``gridd.conf`` and ``client_configuration_token.tok`` files:
 
    .. code-block:: console
 


### PR DESCRIPTION
Addresses https://nvbugspro.nvidia.com/bug/5474866
Preview: https://nvidia.github.io/cloud-native-docs/review/pr-252/gpu-operator/latest/install-gpu-operator-vgpu.html#prerequisites

Signed-off-by: Andrew Chen <andrewch@nvidia.com>