### PR TITLE
Fix RST formatting and style guide compliance

### DIFF
--- a/edge/anthos-guide.rst
+++ b/edge/anthos-guide.rst
@@ -102,7 +102,7 @@ The basic steps described in this document follows this workflow:
 
 #. Configure nodes
 
-   * Ensure each node (including the control plane) meets the pre-requisites, including time synchronization, correct versions of Docker and other conditions.
+   * Ensure each node (including the control plane) meets the prerequisites, including time synchronization, correct versions of Docker and other conditions.
 
 #. Configure networking (Optional)
 

--- a/gpu-operator/gpu-operator-kubevirt.rst
+++ b/gpu-operator/gpu-operator-kubevirt.rst
@@ -509,10 +509,10 @@ Download the vGPU Software from the `NVIDIA Licensing Portal <https://nvid.nvidi
 
   .. note::
 
-      NVIDIA AI Enterprise customers must use the ``aie`` .run file for building the NVIDIA vGPU Manager image.
-      Download the ``NVIDIA-Linux-x86_64-<version>-vgpu-kvm-aie.run`` file instead, and rename it to
-      ``NVIDIA-Linux-x86_64-<version>-vgpu-kvm.run`` before proceeding with the rest of the procedure.
-      Refer to the ``Infrastructure Support Matrix`` under section under the `NVIDIA AI Enterprise Infra Release Branches <https://docs.nvidia.com/ai-enterprise/index.html#infrastructure-software>`_ for details on supported version number to use. 
+     NVIDIA AI Enterprise customers must use the ``aie`` .run file for building the NVIDIA vGPU Manager image.
+     Download the ``NVIDIA-Linux-x86_64-<version>-vgpu-kvm-aie.run`` file instead, and rename it to
+     ``NVIDIA-Linux-x86_64-<version>-vgpu-kvm.run`` before proceeding with the rest of the procedure.
+     Refer to the ``Infrastructure Support Matrix`` under section under the `NVIDIA AI Enterprise Infra Release Branches <https://docs.nvidia.com/ai-enterprise/index.html#infrastructure-software>`_ for details on supported version number to use. 
   .. end-nvaie-run-file
 
 Next, clone the driver container repository and build the driver image with the following steps.

--- a/gpu-operator/gpu-operator-kubevirt.rst
+++ b/gpu-operator/gpu-operator-kubevirt.rst
@@ -509,10 +509,10 @@ Download the vGPU Software from the `NVIDIA Licensing Portal <https://nvid.nvidi
 
   .. note::
 
-     NVIDIA AI Enterprise customers must use the ``aie`` .run file for building the NVIDIA vGPU Manager image.
-     Download the ``NVIDIA-Linux-x86_64-<version>-vgpu-kvm-aie.run`` file instead, and rename it to
-     ``NVIDIA-Linux-x86_64-<version>-vgpu-kvm.run`` before proceeding with the rest of the procedure.
-     Refer to the ``Infrastructure Support Matrix`` under section under the `NVIDIA AI Enterprise Infra Release Branches <https://docs.nvidia.com/ai-enterprise/index.html#infrastructure-software>`_ for details on supported version number to use. 
+      NVIDIA AI Enterprise customers must use the ``aie`` .run file for building the NVIDIA vGPU Manager image.
+      Download the ``NVIDIA-Linux-x86_64-<version>-vgpu-kvm-aie.run`` file instead, and rename it to
+      ``NVIDIA-Linux-x86_64-<version>-vgpu-kvm.run`` before proceeding with the rest of the procedure.
+      Refer to the ``Infrastructure Support Matrix`` under section under the `NVIDIA AI Enterprise Infra Release Branches <https://docs.nvidia.com/ai-enterprise/index.html#infrastructure-software>`_ for details on supported version number to use. 
   .. end-nvaie-run-file
 
 Next, clone the driver container repository and build the driver image with the following steps.

--- a/kubernetes/index.rst
+++ b/kubernetes/index.rst
@@ -23,7 +23,7 @@ This document provides an overview of the necessary software to enable MIG suppo
 Refer to the `MIG User Guide <https://docs.nvidia.com/datacenter/tesla/mig-user-guide/index.html>`__ for more details on the technical concepts,
 setting up MIG and the NVIDIA Container Toolkit for running containers with MIG.
 
-The deployment workflow requires these pre-requisites:
+The deployment workflow requires these prerequisites:
 
 #. You have installed the NVIDIA R450+ datacenter (450.80.02+) drivers required for NVIDIA A100.
 #. You have installed the NVIDIA Container Toolkit v2.5.0+

--- a/mig/mig-k8s.rst
+++ b/mig/mig-k8s.rst
@@ -13,7 +13,7 @@ This document provides steps on getting started and running some example CUDA wo
 on MIG-enabled GPUs in a Kubernetes cluster.
 
 ************************
-Software Pre-requisites
+Software Prerequisites
 ************************
 
 The deployment workflow requires these prerequisites. Once these prerequisites have been met, 

--- a/openshift/appendix-ocp.rst
+++ b/openshift/appendix-ocp.rst
@@ -23,14 +23,14 @@ Introduction
 
    If you encounter the :ref:`"broken driver toolkit detected" <broken-dtk>` warning on OpenShift 4.10 or later, you should :ref:`troubleshoot <broken-dtk-troubleshooting>` to find the root cause instead of falling back to entitled driver builds.
 
-   If the broken DTK warning is encountered on an older version of OpenShift, refer to the documentation for an older version of the NVIDIA GPU operator to enable entitled builds. Keep in mind that older versions of OpenShift might no longer be supported.
+   If the broken DTK warning is encountered on an older version of OpenShift, refer to the documentation for an older version of the NVIDIA GPU Operator to enable entitled builds. Keep in mind that older versions of OpenShift might no longer be supported.
 
 .. _broken-dtk-troubleshooting:
 
 Troubleshooting Broken Driver Toolkit Errors
 --------------------------------------------
 
-The most likely reason for the broken DTK message is Node Feature Discovery (NFD) not working correctly. NFD might be disabled, failing, or not updating the kernel version label for other reasons. Another cause might be a missing or incomplete DTK image stream, e.g. because of broken mirroring.
+The most likely reason for the broken DTK message is Node Feature Discovery (NFD) not working correctly. NFD might be disabled, failing, or not updating the kernel version label for other reasons. Another cause might be a missing or incomplete DTK image stream, for example, because of broken mirroring.
 
 Follow these steps for initial troubleshooting of Node Feature Discovery:
 
@@ -48,7 +48,7 @@ Follow these steps for initial troubleshooting of Node Feature Discovery:
 
       $ oc get nodes -o jsonpath='{range .items[*]}{.metadata.name}{":\t"}{.metadata.labels.feature\.node\.kubernetes\.io/kernel-version\.full}{"\n"}{end}'
 
-   Ensure nodes have proper kernel version labels that match current OpenShift version of the cluster.
+   Ensure nodes have proper kernel version labels that match the current OpenShift version of the cluster.
 
 #. **Check Driver Toolkit image stream:**
 
@@ -56,7 +56,7 @@ Follow these steps for initial troubleshooting of Node Feature Discovery:
 
       $ oc get -n openshift is/driver-toolkit
 
-   Verify the driver-toolkit image stream exists and has the correct tags that correspond to current OpenShift version.
+   Verify the driver-toolkit image stream exists and has the correct tags that correspond to the current OpenShift version.
 
 For additional troubleshooting resources:
 

--- a/openshift/clean-up.rst
+++ b/openshift/clean-up.rst
@@ -6,11 +6,11 @@
 *****************************************
 Cleanup
 *****************************************
-This section describes how to clean up (remove) the GPU Operator in case it is no longer needed.
+This section describes how to clean up (remove) the GPU Operator if it is no longer needed.
 
 #. Delete the NVIDIA GPU Operator from the cluster following the guidance outlined in `Deleting Operators from a cluster <https://docs.openshift.com/container-platform/latest/operators/admin/olm-deleting-operators-from-cluster.html>`_.
 
-#. Delete the cluster policy using the OpenShift Container Platform CLI:
+#. Delete the cluster policy by using the OpenShift Container Platform CLI.
 
    .. code-block:: console
 

--- a/openshift/enable-gpu-monitoring-dashboard.rst
+++ b/openshift/enable-gpu-monitoring-dashboard.rst
@@ -83,9 +83,9 @@ The following table provides a brief description of the graphs on the default da
 +--------------------------+------------------------------------------------------------+
 | Graph                    | Description                                                |
 +==========================+============================================================+
-| GPU Temperature          | GPU temperature in C.                                      |
+| GPU Temperature          | GPU temperature in Celsius.                                      |
 +--------------------------+------------------------------------------------------------+
-| GPU Avg. Temp            | Average GPU temperature in C.                              |
+| GPU Avg. Temp            | Average GPU temperature in Celsius.                              |
 +--------------------------+------------------------------------------------------------+
 | GPU Power Usage          | Power usage in watts for each GPU.                         |
 +--------------------------+------------------------------------------------------------+

--- a/openshift/enable-gpu-monitoring-dashboard.rst
+++ b/openshift/enable-gpu-monitoring-dashboard.rst
@@ -83,9 +83,9 @@ The following table provides a brief description of the graphs on the default da
 +--------------------------+------------------------------------------------------------+
 | Graph                    | Description                                                |
 +==========================+============================================================+
-| GPU Temperature          | GPU temperature in Celsius.                                      |
+| GPU Temperature          | GPU temperature in Celsius.                                |
 +--------------------------+------------------------------------------------------------+
-| GPU Avg. Temp            | Average GPU temperature in Celsius.                              |
+| GPU Avg. Temp            | Average GPU temperature in Celsius.                        |
 +--------------------------+------------------------------------------------------------+
 | GPU Power Usage          | Power usage in watts for each GPU.                         |
 +--------------------------+------------------------------------------------------------+

--- a/openshift/get-entitlement.rst
+++ b/openshift/get-entitlement.rst
@@ -11,4 +11,4 @@ Entitled Driver Builds No Longer Supported
 
    **Entitled NVIDIA driver builds are deprecated and not supported.**
 
-   If you encounter issues with the NVIDIA GPU driver build that might require entitlement, please refer to the Driver Toolkit (DTK) troubleshooting section: :ref:`broken-dtk-troubleshooting`
+   If you encounter issues with the NVIDIA GPU driver build that might require entitlement, refer to the Driver Toolkit (DTK) troubleshooting section: :ref:`broken-dtk-troubleshooting`.

--- a/openshift/install-gpu-ocp.rst
+++ b/openshift/install-gpu-ocp.rst
@@ -11,20 +11,20 @@ Installing the NVIDIA GPU Operator on OpenShift
 Installing the NVIDIA GPU Operator by using the web console
 ***********************************************************
 
-#. In the OpenShift Container Platform web console from the side menu, navigate to  **Operators** > **OperatorHub** and select **All Projects**.
+#. In the OpenShift Container Platform web console, from the side menu, navigate to **Operators** > **OperatorHub** and select **All Projects**.
 
-#. In **Operators** > **OperatorHub**, search for the **NVIDIA GPU Operator**. For additional information see the `Red Hat OpenShift Container Platform documentation <https://docs.openshift.com/container-platform/latest/operators/admin/olm-adding-operators-to-cluster.html>`_.
+#. In **Operators** > **OperatorHub**, search for the **NVIDIA GPU Operator**. For additional information, refer to the `Red Hat OpenShift Container Platform documentation <https://docs.openshift.com/container-platform/latest/operators/admin/olm-adding-operators-to-cluster.html>`_.
 
-#. Select the **NVIDIA GPU Operator**, click **Install**. In the subsequent screen click **Install**.
+#. Select the **NVIDIA GPU Operator**, click **Install**. In the following screen, click **Install**.
 
-  .. note:: Here, you can select the namespace where you want to deploy the GPU Operator. The suggested namespace to use is the ``nvidia-gpu-operator``. You can choose any existing namespace or create a new namespace under **Select a Namespace**.
+   .. note:: Here, you can select the namespace where you want to deploy the GPU Operator. The suggested namespace to use is the ``nvidia-gpu-operator``. You can choose any existing namespace or create a new namespace under **Select a Namespace**.
 
-            If you install in any other namespace other than ``nvidia-gpu-operator``, the GPU Operator will **not** automatically enable namespace monitoring, and metrics and alerts will **not** be collected by Prometheus.
-            If only trusted operators are installed in this namespace, you can manually enable namespace monitoring with this command:
+     If you install in any other namespace other than ``nvidia-gpu-operator``, the GPU Operator will **not** automatically enable namespace monitoring, and metrics and alerts will **not** be collected by Prometheus.
+     If only trusted operators are installed in this namespace, you can manually enable namespace monitoring with this command:
 
-            .. code-block:: console
+     .. code-block:: console
 
-               $ oc label ns/$NAMESPACE_NAME openshift.io/cluster-monitoring=true
+        $ oc label ns/$NAMESPACE_NAME openshift.io/cluster-monitoring=true
 
 Proceed to :ref:`Create the cluster policy for the NVIDIA GPU Operator <create-cluster-policy>`.
 
@@ -36,7 +36,7 @@ As a cluster administrator, you can install the **NVIDIA GPU Operator** using th
 
 #. Create a namespace for the **NVIDIA GPU Operator**.
 
-   #. Create the following ``Namespace`` custom resource (CR) that defines the ``nvidia-gpu-operator`` namespace, and then save the YAML in the ``nvidia-gpu-operator.yaml`` file:
+   #. Create the following ``Namespace`` custom resource (CR) that defines the ``nvidia-gpu-operator`` namespace and then save the YAML in the ``nvidia-gpu-operator.yaml`` file:
 
       .. code-block:: yaml
 
@@ -45,14 +45,14 @@ As a cluster administrator, you can install the **NVIDIA GPU Operator** using th
          metadata:
            name: nvidia-gpu-operator
 
-      .. note:: The suggested namespace to use is the ``nvidia-gpu-operator``. You can choose any existing namespace or create a new namespace name.
-                If you install in any other namespace other than ``nvidia-gpu-operator``, the GPU Operator will **not** automatically enable namespace monitoring, and metrics and alerts will **not** be collected by Prometheus.
+      .. note:: The suggested namespace to use is the ``nvidia-gpu-operator``. You can choose any existing namespace or create a new namespace.
+         If you install in any other namespace other than ``nvidia-gpu-operator``, the GPU Operator will **not** automatically enable namespace monitoring, and metrics and alerts will **not** be collected by Prometheus.
 
-                If only trusted operators are installed in this namespace, you can manually enable namespace monitoring with this command:
+         If only trusted operators are installed in this namespace, you can manually enable namespace monitoring with this command:
 
-                 .. code-block:: console
+         .. code-block:: console
 
-                    $ oc label ns/$NAMESPACE_NAME openshift.io/cluster-monitoring=true
+            $ oc label ns/$NAMESPACE_NAME openshift.io/cluster-monitoring=true
 
    #. Create the namespace by running the following command:
 
@@ -76,8 +76,8 @@ As a cluster administrator, you can install the **NVIDIA GPU Operator** using th
            name: nvidia-gpu-operator-group
            namespace: nvidia-gpu-operator
          spec:
-          targetNamespaces:
-          - nvidia-gpu-operator
+           targetNamespaces:
+           - nvidia-gpu-operator
 
    #. Create the ``OperatorGroup`` CR by running the following command:
 
@@ -89,19 +89,19 @@ As a cluster administrator, you can install the **NVIDIA GPU Operator** using th
 
          operatorgroup.operators.coreos.com/nvidia-gpu-operator-group created
 
-#. Run the following command to get the ``channel`` value required for step number 5.
+#. Run the following command to get the ``channel`` value required for step 5.
 
    .. code-block:: console
 
       $ oc get packagemanifest gpu-operator-certified -n openshift-marketplace -o jsonpath='{.status.defaultChannel}'
 
-   **Example output**
+   *Example Output*
 
    .. code-block:: console
 
       v22.9
 
-#. Run the following commands to get the ``startingCSV`` value required for step number 5.
+#. Run the following commands to get the ``startingCSV`` value required for step 5.
 
    .. code-block:: console
 
@@ -111,7 +111,7 @@ As a cluster administrator, you can install the **NVIDIA GPU Operator** using th
 
       $ oc get packagemanifests/gpu-operator-certified -n openshift-marketplace -ojson | jq -r '.status.channels[] | select(.name == "'$CHANNEL'") | .currentCSV'
 
-   **Example output**
+   *Example Output*
 
    .. code-block:: console
 
@@ -134,7 +134,7 @@ As a cluster administrator, you can install the **NVIDIA GPU Operator** using th
         sourceNamespace: openshift-marketplace
         startingCSV: "gpu-operator-certified.v22.9.0"
 
-   .. note:: Update the ``channel`` and ``startingCSV`` fields with the information returned in step 3 and 4.
+   .. note:: Update the ``channel`` and ``startingCSV`` fields with the information returned in steps 3 and 4.
 
 #. Create the subscription object by running the following command:
 
@@ -146,7 +146,7 @@ As a cluster administrator, you can install the **NVIDIA GPU Operator** using th
 
       subscription.operators.coreos.com/gpu-operator-certified created
 
-#. Optional: Log in to web console and navigate to the **Operators** > **Installed Operators** page. In the ``Project: nvidia-gpu-operator`` the following is displayed:
+#. Optional: Log in to the web console and navigate to the **Operators** > **Installed Operators** page. In the ``Project: nvidia-gpu-operator`` the following is displayed:
 
    .. image:: graphics/gpu-operator-certified-cli-install.png
 
@@ -156,7 +156,7 @@ As a cluster administrator, you can install the **NVIDIA GPU Operator** using th
 
       $ oc get installplan -n nvidia-gpu-operator
 
-   **Example output**
+   *Example Output*
 
    .. code-block:: console
 
@@ -173,7 +173,7 @@ As a cluster administrator, you can install the **NVIDIA GPU Operator** using th
 
       $ oc patch $INSTALL_PLAN -n nvidia-gpu-operator --type merge --patch '{"spec":{"approved":true }}'
 
-   **Example output**
+   *Example Output*
 
    .. code-block:: console
 
@@ -193,12 +193,12 @@ As a cluster administrator, you can install the **NVIDIA GPU Operator** using th
 Create the ClusterPolicy instance
 *********************************
 
-When you install the **NVIDIA GPU Operator** in the OpenShift Container Platform, a custom resource definition for a ClusterPolicy is created. The ClusterPolicy configures the GPU stack, configuring the image names and repository, pod restrictions/credentials and so on.
+When you install the **NVIDIA GPU Operator** in the OpenShift Container Platform, a custom resource definition for a ClusterPolicy is created. The ClusterPolicy configures the GPU stack, configuring the image names and repository, pod restrictions and credentials, and more.
 
-.. note:: If you create a ClusterPolicy that contains an empty specification, such as ``spec{}``, the ClusterPolicy fails to deploy.
+.. note:: If you create a ClusterPolicy that contains an empty specification such as ``spec{}``, the ClusterPolicy fails to deploy.
 
 As a cluster administrator, you can create a ClusterPolicy using the OpenShift Container Platform CLI or the web console. Also, these steps differ
-when using **NVIDIA vGPU**. Please refer to appropriate sections below.
+when using **NVIDIA vGPU**. Refer to the appropriate sections that follow.
 
 .. _create-cluster-policy-web-console:
 
@@ -209,13 +209,13 @@ Create the cluster policy using the web console
 
 #. Select the **ClusterPolicy** tab, then click **Create ClusterPolicy**. The platform assigns the default name *gpu-cluster-policy*.
 
-      .. note:: You can use this screen to customize the ClusterPolicy; although, the default values are sufficient to get the GPU configured and running in most cases.
+   .. note:: You can use this screen to customize the ClusterPolicy; although, the default values are sufficient to get the GPU configured and running in most cases.
 
-      .. note:: For OpenShift 4.12 with GPU Operator 25.3.1 or later, you must expand the **Driver** section and set the following fields:
+   .. note:: For OpenShift 4.12 with GPU Operator 25.3.1 or later, you must expand the **Driver** section and set the following fields:
 
-         - **version**: 570.172.08 (or another supported version)
-         - **image**: driver (or another supported image)
-         - **repository**: nvcr.io/nvidia (or another supported repository)
+      - **version**: 570.172.08 (or another supported version)
+      - **image**: driver (or another supported image)
+      - **repository**: nvcr.io/nvidia (or another supported repository)
 
 #. Click **Create**.
 
@@ -223,7 +223,7 @@ Create the cluster policy using the web console
 
 #. The status of the newly deployed ClusterPolicy *gpu-cluster-policy* for the NVIDIA GPU Operator changes to ``State:ready`` when the installation succeeds.
 
- .. image:: graphics/cluster-policy-state-ready.png
+   .. image:: graphics/cluster-policy-state-ready.png
 
 .. _verify-gpu-operator-install-ocp:
 
@@ -237,7 +237,7 @@ Create the cluster policy using the CLI
       $ oc get csv -n nvidia-gpu-operator gpu-operator-certified.v22.9.0 -ojsonpath={.metadata.annotations.alm-examples} | jq .[0] > clusterpolicy.json
 
 
-   .. note:: For OpenShift 4.12 with GPU Operator 25.3.1 or later, modify clusterpolicy.json file to specify ``driver.licensingConfig``, ``driver.repository``, ``driver.image``, ``driver.version`` and ``driver.imagePullSecrets`` (optional). The below snippet is shown as an example, please change values accordingly. Refer to :ref:`operator-release-notes` for recommended driver versions.
+   .. note:: For OpenShift 4.12 with GPU Operator 25.3.1 or later, modify the clusterpolicy.json file to specify ``driver.licensingConfig``, ``driver.repository``, ``driver.image``, ``driver.version``, and ``driver.imagePullSecrets`` (optional). The following snippet is shown as an example. Change values accordingly. Refer to :ref:`operator-release-notes` for recommended driver versions.
 
    .. code-block:: json
 
@@ -262,7 +262,7 @@ Create the ClusterPolicy instance with NVIDIA vGPU
 Pre-requisites
 --------------
 
-* Please refer to :ref:`install-gpu-operator-vgpu` section for pre-requisite steps for using NVIDIA vGPU on RedHat OpenShift.
+* Refer to the :ref:`install-gpu-operator-vgpu` section for prerequisite steps for using NVIDIA vGPU on Red Hat OpenShift.
 
 Create the cluster policy using the web console
 -----------------------------------------------
@@ -271,13 +271,13 @@ Create the cluster policy using the web console
 
 #. Select the **ClusterPolicy** tab, then click **Create ClusterPolicy**. The platform assigns the default name *gpu-cluster-policy*.
 
-#. Provide name of the licensing ``ConfigMap`` under **Driver** section, this should be created during pre-requsite steps above for NVIDIA vGPU. Refer to below screenshots for example and modify values accordingly.
+#. Provide the name of the licensing ``ConfigMap`` under the **Driver** section. This should be created during the prerequisite steps for NVIDIA vGPU. Refer to the following screenshots for examples and modify values accordingly.
 
- .. image:: graphics/cluster_policy_vgpu_1.png
+   .. image:: graphics/cluster_policy_vgpu_1.png
 
 #. Specify ``repository`` path, ``image`` name and NVIDIA vGPU driver ``version`` bundled under **Driver** section. If the registry is not public, please specify the ``imagePullSecret`` created during pre-requisite step under **Driver** advanced configurations section.
 
- .. image:: graphics/cluster_policy_vgpu_2.png
+   .. image:: graphics/cluster_policy_vgpu_2.png
 
 #. Click **Create**.
 
@@ -285,7 +285,7 @@ Create the cluster policy using the web console
 
 #. The status of the newly deployed ClusterPolicy *gpu-cluster-policy* for the NVIDIA GPU Operator changes to ``State:ready`` when the installation succeeds.
 
- .. image:: graphics/cluster-policy-state-ready.png
+   .. image:: graphics/cluster-policy-state-ready.png
 
 
 Create the cluster policy using the CLI
@@ -302,13 +302,13 @@ Create the cluster policy using the CLI
    .. code-block:: json
 
          "driver": {
-              "repository": "<repository-path>"
+              "repository": "<repository-path>",
               "image": "driver",
               "imagePullSecrets": [],
               "licensingConfig": {
                 "configMapName": "licensing-config",
                 "nlsEnabled": true
-              }
+              },
               "version": "470.82.01"
          }
 
@@ -361,7 +361,7 @@ Verify the successful installation of the NVIDIA GPU Operator as shown here:
    The ``nvidia-driver-daemonset`` pod runs on each worker node that contains a supported NVIDIA GPU.
 
    .. note:: When the Driver Toolkit is active, the ``DaemonSet`` is named ``nvidia-driver-daemonset-<RHCOS-version>``. Where ``RHCOS-version`` equals ``<OCP XY>.<RHEL XY>.<related date YYYYMMDDHHSS-0``.
-             The pods of the ``DaemonSet`` are named ``nvidia-driver-daemonset-<RHCOS-version>-<UUID>``.
+      The pods of the ``DaemonSet`` are named ``nvidia-driver-daemonset-<RHCOS-version>-<UUID>``.
 
 *************************************************************
 Cluster monitoring
@@ -374,17 +374,17 @@ If the label is defined, the GPU Operator will not change its value.
 
 Disable cluster monitoring in the ``nvidia-gpu-operator`` namespace by setting ``openshift.io/cluster-monitoring=false`` as shown:
 
-   .. code-block:: console
+.. code-block:: console
 
-       $ oc label ns/nvidia-gpu-operator openshift.io/cluster-monitoring=false
+   $ oc label ns/nvidia-gpu-operator openshift.io/cluster-monitoring=false
 
 If the GPU Operator is not installed in the suggested namespace, the GPU Operator will not automatically enable monitoring. Set the label manually as shown:
 
-   .. code-block:: console
+.. code-block:: console
 
-      $ oc label ns/$NAMESPACE openshift.io/cluster-monitoring=true
+   $ oc label ns/$NAMESPACE openshift.io/cluster-monitoring=true
 
-   .. note:: Only do this if trusted operators are installed in this namespace.
+.. note:: Only do this if trusted operators are installed in this namespace.
 
 *************************************************************
 Logging
@@ -414,7 +414,7 @@ The ``nvidia-driver-daemonset`` pod has two containers.
 Running a sample GPU Application
 *************************************************************
 
-Run a simple CUDA VectorAdd sample, which adds two vectors together to ensure the GPUs have bootstrapped correctly.
+Run a simple CUDA VectorAdd sample that adds two vectors together to ensure the GPUs have bootstrapped correctly.
 
 #. Run the following:
 
@@ -427,13 +427,13 @@ Run a simple CUDA VectorAdd sample, which adds two vectors together to ensure th
       metadata:
         name: cuda-vectoradd
       spec:
-       restartPolicy: OnFailure
-       containers:
-       - name: cuda-vectoradd
-         image: "nvcr.io/nvidia/k8s/cuda-sample:vectoradd-cuda12.5.0-ubi8"
-         resources:
-           limits:
-             nvidia.com/gpu: 1
+        restartPolicy: OnFailure
+        containers:
+        - name: cuda-vectoradd
+          image: "nvcr.io/nvidia/k8s/cuda-sample:vectoradd-cuda12.5.0-ubi8"
+          resources:
+            limits:
+              nvidia.com/gpu: 1
       EOF
 
    .. code-block:: console

--- a/openshift/install-gpu-ocp.rst
+++ b/openshift/install-gpu-ocp.rst
@@ -259,7 +259,7 @@ Create the cluster policy using the CLI
 Create the ClusterPolicy instance with NVIDIA vGPU
 ***************************************************************************
 
-Pre-requisites
+Prerequisites
 --------------
 
 * Refer to the :ref:`install-gpu-operator-vgpu` section for prerequisite steps for using NVIDIA vGPU on Red Hat OpenShift.

--- a/openshift/install-nfd.rst
+++ b/openshift/install-nfd.rst
@@ -11,9 +11,9 @@ Installing the Node Feature Discovery Operator on OpenShift
 Procedure
 *********
 
-The Node Feature Discovery (NFD) Operator is a prerequisite for the **NVIDIA GPU Operator**. Install the NFD Operator using the Red Hat OperatorHub catalog in the OpenShift Container Platform web console .
+The Node Feature Discovery (NFD) Operator is a prerequisite for the **NVIDIA GPU Operator**. Install the NFD Operator using the Red Hat OperatorHub catalog in the OpenShift Container Platform web console.
 
-#. Follow the Red Hat documentation guidance in `The Node Feature Discovery Operator <https://docs.openshift.com/container-platform/latest/hardware_enablement/psap-node-feature-discovery-operator.html>`_ to install the Node Feature Discovery Operator.
+#. Follow the Red Hat documentation guidance in the `Node Feature Discovery Operator guide <https://docs.openshift.com/container-platform/latest/hardware_enablement/psap-node-feature-discovery-operator.html>`_ to install the Node Feature Discovery Operator.
 
 #. Verify the Node Feature Discovery Operator is running:
 
@@ -28,40 +28,40 @@ The Node Feature Discovery (NFD) Operator is a prerequisite for the **NVIDIA GPU
 
 #. When the Node Feature Discovery is installed, create an instance of Node Feature Discovery using the **NodeFeatureDiscovery** tab.
 
- #. Click **Operators** > **Installed Operators** from the side menu.
+   #. Click **Operators** > **Installed Operators** from the side menu.
 
- #. Find the **Node Feature Discovery** entry.
+   #. Find the **Node Feature Discovery** entry.
 
- #. Click **NodeFeatureDiscovery** under the **Provided APIs** field.
+   #. Click **NodeFeatureDiscovery** under the **Provided APIs** field.
 
- #. Click **Create NodeFeatureDiscovery**.
+   #. Click **Create NodeFeatureDiscovery**.
 
- #. In the subsequent screen click **Create**. This starts the Node Feature Discovery Operator that proceeds to label the nodes in the cluster that have GPUs.
+   #. In the following screen, click **Create**. This starts the Node Feature Discovery Operator that proceeds to label the nodes in the cluster that have GPUs.
 
-      .. note:: The values pre-populated by the OperatorHub are valid for the GPU Operator.
+      .. note:: The values prepopulated by the OperatorHub are valid for the GPU Operator.
 
 *************************************************************************
 Verify that the Node Feature Discovery Operator is functioning correctly
 *************************************************************************
 
-The Node Feature Discovery Operator uses vendor PCI IDs to identify hardware in a node. NVIDIA uses the PCI ID 10de. Use the OpenShift Container Platform web console or the CLI to verify that the Node Feature Discovery Operator is functioning correctly.
+The Node Feature Discovery Operator uses vendor PCI IDs to identify hardware in a node. NVIDIA uses the PCI ID ``10de``. Use the OpenShift Container Platform web console or the CLI to verify that the Node Feature Discovery Operator is functioning correctly.
 
 
 #. In the OpenShift Container Platform web console, click **Compute** > **Nodes** from the side menu.
 
-#. Select a worker node that you know contains a GPU.
+#. Select a worker node that contains a GPU.
 
 #. Click the **Details** tab.
 
-#. Under **Node labels** verify that the following label is present:
+#. Under **Node Labels**, verify that the following label is present:
 
    .. code-block:: console
 
       feature.node.kubernetes.io/pci-10de.present=true
 
-   .. note:: ``0x10de`` is the PCI vendor ID that is assigned to NVIDIA.
+   .. note:: ``0x10de`` is the PCI vendor ID assigned to NVIDIA.
 
-#. Verify the GPU device (``pci-10de``) is discovered on the GPU node:
+#. Verify that the GPU device (``pci-10de``) is discovered on the GPU node.
 
    .. code-block:: console
 

--- a/openshift/introduction.rst
+++ b/openshift/introduction.rst
@@ -13,11 +13,11 @@ Introduction to NVIDIA GPU Operator on OpenShift
 Kubernetes is an open-source platform for automating the deployment, scaling, and managing of containerized applications.
 
 Red Hat OpenShift Container Platform is a security-centric and enterprise-grade hardened Kubernetes platform for deploying and managing Kubernetes clusters at scale, developed and supported by Red Hat.
-Red Hat OpenShift Container Platform includes enhancements to Kubernetes so users can easily configure and use GPU resources for accelerating workloads such as deep learning.
+Red Hat OpenShift Container Platform includes enhancements to Kubernetes so users can easily configure and use GPU resources for accelerating workloads like deep learning.
 
 The NVIDIA GPU Operator uses the operator framework within Kubernetes to automate the management of all NVIDIA software components needed to provision GPU. These components include the NVIDIA drivers (to enable CUDA),
 Kubernetes device plugin for GPUs, the `NVIDIA Container Toolkit <https://github.com/NVIDIA/nvidia-container-toolkit>`_,
-automatic node labelling using `GFD <https://github.com/NVIDIA/gpu-feature-discovery>`_, `DCGM <https://developer.nvidia.com/dcgm>`_ based monitoring and others.
+automatic node labeling using `GFD <https://github.com/NVIDIA/gpu-feature-discovery>`_, `DCGM <https://developer.nvidia.com/dcgm>`_-based monitoring and others.
 
 For guidance on the specific NVIDIA support entitlement needs,
 refer |essug|_ if you have an NVIDIA AI Enterprise entitlement.

--- a/openshift/mig-ocp.rst
+++ b/openshift/mig-ocp.rst
@@ -76,33 +76,40 @@ MIG advertisement strategies
 The NVIDIA GPU Operator exposes GPUs to Kubernetes as extended resources that can be requested and exposed into Pods and containers. The first step of the MIG configuration is to decide what **Strategy** you want. The advertisement strategies are described here:
 
 
-* **Single** defines a homogeneous advertisement strategy, with MIG instances exposed as usual GPUs. This strategy exposes the MIG instances as ``nvidia.com/gpu`` resources, identically, as usual non-MIG capable (or with MIG disabled) devices. In this strategy, all the GPUs in a single node must be configured in a homogeneous manner (same number of compute units, same memory size). This strategy is best for a large cluster where the infrastructure teams can configure “node pools” of different MIG geometries and make them available to users. Another advantage of this strategy is backward compatibility where the existing application does not have to be modified to be scheduled this way.
+* **Single** defines a homogeneous advertisement strategy, with MIG instances exposed as usual GPUs.
+  This strategy exposes the MIG instances as ``nvidia.com/gpu`` resources, identically, as usual non-MIG capable (or with MIG disabled) devices.
+  In this strategy, all the GPUs in a single node must be configured in a homogeneous manner (same number of compute units, same memory size).
+  This strategy is best for a large cluster where the infrastructure teams can configure “node pools” of different MIG geometries and make them available to users.
+  Another advantage of this strategy is backward compatibility where the existing application does not have to be modified to be scheduled this way.
 
-   Examples for the A100-40GB:
+  Examples for the A100-40GB:
 
-   * 1g.5gb:  7 nvidia.com/gpu instances, or
-   * 2g.10gb: 3 nvidia.com/gpu instances, or
-   * 3g.20gb: 2 nvidia.com/gpuinstances, or
-   * 7g.40gb: 1 nvidia.com/gpu instances
+  * 1g.5gb:  7 nvidia.com/gpu instances, or
+  * 2g.10gb: 3 nvidia.com/gpu instances, or
+  * 3g.20gb: 2 nvidia.com/gpuinstances, or
+  * 7g.40gb: 1 nvidia.com/gpu instances
 
-   .. image:: graphics/Mig-profile-A100.png
+  .. image:: graphics/Mig-profile-A100.png
 
-* **Mixed** defines a heterogeneous advertisement strategy. There is no constraint on the geometry; all the combinations allowed by the GPU are permitted. This strategy is appropriate for a smaller cluster, where on a single node with multiple GPUs, each GPU can be configured in a different MIG geometry.
+* **Mixed** defines a heterogeneous advertisement strategy.
+  There is no constraint on the geometry; all the combinations allowed by the GPU are permitted.
+  This strategy is appropriate for a smaller cluster, where on a single node with multiple GPUs, each GPU can be configured in a different MIG geometry.
 
-   Examples for the A100-40GB:
+  Examples for the A100-40GB:
 
-   * All the **single** configurations are possible
-   * A “balanced” configuration:
+  * All the **single** configurations are possible
+  * A “balanced” configuration:
 
-      * 1g.5gb:  2 nvidia.com/mig-1g.5gb instances, and
-      * 2g.10gb: 1 nvidia.com/mig-2g.10gb instance, and
-      * 3g.20gb: 1 nvidia.com/mig-3g.20gb instance
+    * 1g.5gb:  2 nvidia.com/mig-1g.5gb instances, and
+    * 2g.10gb: 1 nvidia.com/mig-2g.10gb instance, and
+    * 3g.20gb: 1 nvidia.com/mig-3g.20gb instance
 
-   .. image:: graphics/mig-mixed-profile-A100.png
+  .. image:: graphics/mig-mixed-profile-A100.png
 
 Version 1.8 and greater of the NVIDIA GPU Operator supports updating the **Strategy** in the ClusterPolicy after deployment.
 
-The `default configmap <https://gitlab.com/nvidia/kubernetes/gpu-operator/-/blob/v1.8.0/assets/state-mig-manager/0400_configmap.yaml>`_ defines the combination of single (homogeneous) and mixed (heterogeneous) profiles that are supported for A100-40GB, A100-80GB and A30-24GB. The configmap allows administrators to declaratively define a set of possible MIG configurations they would like applied to all GPUs on a node.
+The `default configmap <https://gitlab.com/nvidia/kubernetes/gpu-operator/-/blob/v1.8.0/assets/state-mig-manager/0400_configmap.yaml>`_ defines the combination of single (homogeneous) and mixed (heterogeneous) profiles that are supported for A100-40GB, A100-80GB and A30-24GB.
+The configmap allows administrators to declaratively define a set of possible MIG configurations they would like applied to all GPUs on a node.
 The tables below describe these configurations:
 
 .. table:: Single configuration

--- a/openshift/mig-ocp.rst
+++ b/openshift/mig-ocp.rst
@@ -85,7 +85,7 @@ The NVIDIA GPU Operator exposes GPUs to Kubernetes as extended resources that ca
    * 3g.20gb: 2 nvidia.com/gpuinstances, or
    * 7g.40gb: 1 nvidia.com/gpu instances
 
-     .. image:: graphics/Mig-profile-A100.png
+   .. image:: graphics/Mig-profile-A100.png
 
 * **Mixed** defines a heterogeneous advertisement strategy. There is no constraint on the geometry; all the combinations allowed by the GPU are permitted. This strategy is appropriate for a smaller cluster, where on a single node with multiple GPUs, each GPU can be configured in a different MIG geometry.
 
@@ -98,7 +98,7 @@ The NVIDIA GPU Operator exposes GPUs to Kubernetes as extended resources that ca
      * 2g.10gb: 1 nvidia.com/mig-2g.10gb instance, and
      * 3g.20gb: 1 nvidia.com/mig-3g.20gb instance
 
-     .. image:: graphics/mig-mixed-profile-A100.png
+   .. image:: graphics/mig-mixed-profile-A100.png
 
 Version 1.8 and greater of the NVIDIA GPU Operator supports updating the **Strategy** in the ClusterPolicy after deployment.
 

--- a/openshift/mig-ocp.rst
+++ b/openshift/mig-ocp.rst
@@ -15,7 +15,7 @@ Introduction
 ************
 
 NVIDIA Mult-Instance GPU (MIG) is useful anytime you have an application that does not require the full power of an entire GPU.
-The new NVIDIA Ampere architecture’s MIG feature allows you to split your hardware resources into multiple GPU instances, each exposed to the operating system as an independent CUDA-enabled GPU. The NVIDIA GPU Operator version 1.7.0 and above provides MIG feature support for the A100 and A30 Ampere cards.
+The new NVIDIA Ampere architecture's MIG feature allows you to split your hardware resources into multiple GPU instances, each exposed to the operating system as an independent CUDA-enabled GPU. The NVIDIA GPU Operator version 1.7.0 and above provides MIG feature support for the A100 and A30 Ampere cards.
 These GPU instances are designed to support multiple independent CUDA applications (up to 7), so they operate completely isolated from each other using dedicated hardware resources.
 
 The compute units of the GPU, in addition to its memory, can be partitioned into multiple MIG instances.
@@ -94,9 +94,9 @@ The NVIDIA GPU Operator exposes GPUs to Kubernetes as extended resources that ca
    * All the **single** configurations are possible
    * A “balanced” configuration:
 
-     * 1g.5gb:  2 nvidia.com/mig-1g.5gb instances, and
-     * 2g.10gb: 1 nvidia.com/mig-2g.10gb instance, and
-     * 3g.20gb: 1 nvidia.com/mig-3g.20gb instance
+      * 1g.5gb:  2 nvidia.com/mig-1g.5gb instances, and
+      * 2g.10gb: 1 nvidia.com/mig-2g.10gb instance, and
+      * 3g.20gb: 1 nvidia.com/mig-3g.20gb instance
 
    .. image:: graphics/mig-mixed-profile-A100.png
 
@@ -888,7 +888,7 @@ For information about the initial default MIG configuration and viewing it, refe
 Running a sample GPU application
 *************************************************************
 
-Let’s run a simple CUDA sample, in this case ``vectorAdd`` by requesting a GPU resource as you would normally do in Kubernetes.
+Let's run a simple CUDA sample, in this case ``vectorAdd`` by requesting a GPU resource as you would normally do in Kubernetes.
 
 If the cluster is configured with the ``mixed`` advertisement strategy.
 
@@ -963,10 +963,10 @@ Disable the MIG mode
 
 To turn MIG mode off so that you can utilize the full capacity of the GPU run the following:
 
-   .. code-block:: console
+.. code-block:: console
 
-      $ MIG_CONFIGURATION=all-disabled && \
-        oc label node/$NODE_NAME nvidia.com/mig.config=$MIG_CONFIGURATION --overwrite
+   $ MIG_CONFIGURATION=all-disabled && \
+      oc label node/$NODE_NAME nvidia.com/mig.config=$MIG_CONFIGURATION --overwrite
 
 *************************************************************
 Troubleshooting
@@ -982,14 +982,14 @@ The MIG reconfiguration is handled exclusively by the controller deployed within
 
    The cluster administrator is expected to drain the node from any GPU workload, before requesting the MIG reconfiguration. If the node is not properly drained, the ``nvidia-mig-manager`` will fail with this error in the logs:
 
-      .. code-block:: console
+   .. code-block:: console
 
-          Updating MIG config: map[2g.10gb:3]
-         Error clearing MigConfig: error destroying Compute instance for profile '(0, 0)': In use by another client
-         Error clearing MIG config on GPU 0, erroneous devices may persist
-         Error setting MIGConfig: error attempting multiple config orderings: all orderings failed
-         Restarting all GPU clients previously shutdown by reenabling their component-specific nodeSelector labels
-         Changing the 'nvidia.com/mig.config.state' node label to 'failed'
+      Updating MIG config: map[2g.10gb:3]
+      Error clearing MigConfig: error destroying Compute instance for profile '(0, 0)': In use by another client
+      Error clearing MIG config on GPU 0, erroneous devices may persist
+      Error setting MIGConfig: error attempting multiple config orderings: all orderings failed
+      Restarting all GPU clients previously shutdown by reenabling their component-specific nodeSelector labels
+      Changing the 'nvidia.com/mig.config.state' node label to 'failed'
 
 Resolve this issue by:
 

--- a/openshift/mirror-gpu-ocp-disconnected.rst
+++ b/openshift/mirror-gpu-ocp-disconnected.rst
@@ -41,40 +41,43 @@ provides generic guidance on using Operator Lifecycle Manager on restricted netw
 Prerequisites
 **************
 
-* A working OpenShift cluster up and running with a GPU worker node. See `OpenShift Container Platform installation <https://docs.openshift.com/container-platform/latest/installing/disconnected_install/index.html>`_ for guidance on installing OpenShift Container Platform.
+* A working OpenShift cluster up and running with a GPU worker node.
+  Refer to the `OpenShift Container Platform installation <https://docs.openshift.com/container-platform/latest/installing/disconnected_install/index.html>`_ guide for guidance on installing OpenShift Container Platform.
 
-   .. note:: If installing the **NVIDIA GPU Operator** on OpenShift Container Platform version <``4.9.9`` you need to carry out the steps highlighted as **Optional** below. For more information see :ref:`broken driver toolkit <broken-dtk>`.
+  .. note:: If installing the **NVIDIA GPU Operator** on OpenShift Container Platform version <``4.9.9`` you need to carry out the steps highlighted as **Optional** below.
+      For more information see :ref:`broken driver toolkit <broken-dtk>`.
 
 * Access to the cluster as a user with the ``cluster-admin`` role.
-* Access to a registry that supports `Docker v2-2 <https://docs.docker.com/registry/spec/manifest-v2-2/>`_. A private registry **must** be configured on the bastion host. This can be one of the following registries:
+* Access to a registry that supports `Docker v2-2 <https://docs.docker.com/registry/spec/manifest-v2-2/>`_.
+  A private registry **must** be configured on the bastion host. This can be one of the following registries:
 
-   * `Red Hat Quay <https://www.redhat.com/en/technologies/cloud-computing/quay>`__
-   * `JFrog Artifactory <https://jfrog.com/artifactory/>`_
-   * `Sonatype Nexus Repository <https://www.sonatype.com/products/repository-oss?topnav=true>`_
-   * `Harbor <https://goharbor.io/>`_
+  * `Red Hat Quay <https://www.redhat.com/en/technologies/cloud-computing/quay>`__
+  * `JFrog Artifactory <https://jfrog.com/artifactory/>`_
+  * `Sonatype Nexus Repository <https://www.sonatype.com/products/repository-oss?topnav=true>`_
+  * `Harbor <https://goharbor.io/>`_
 
-   Create a private registry using ``podman`` and guidance on this can be found `here <https://www.redhat.com/sysadmin/simple-container-registry>`__ and in the section :ref:`Creating a private registry`.
+  Create a private registry using ``podman`` and guidance on this can be found `here <https://www.redhat.com/sysadmin/simple-container-registry>`__ and in the section :ref:`Creating a private registry`.
 
-   If you have an entitlement to Red Hat Quay, see the documentation on deploying Red Hat Quay for
-   `proof-of-concept purposes <https://access.redhat.com/documentation/en-us/red_hat_quay/3.5/html/deploy_red_hat_quay_for_proof-of-concept_non-production_purposes/>`__
-   or by using the `Quay Operator <https://access.redhat.com/documentation/en-us/red_hat_quay/3.5/html/deploy_red_hat_quay_on_openshift_with_the_quay_operator/>`__.
-   If you need additional assistance selecting and installing a registry, contact your sales representative or Red Hat support.
-   For more information, refer to `About disconnected install mirroring <https://docs.openshift.com/container-platform/latest/installing/disconnected_install/index.html>`__
-   in the Red Hat OpenShift Container Platform documentation.
+  If you have an entitlement to Red Hat Quay, see the documentation on deploying Red Hat Quay for
+  `proof-of-concept purposes <https://access.redhat.com/documentation/en-us/red_hat_quay/3.5/html/deploy_red_hat_quay_for_proof-of-concept_non-production_purposes/>`__
+  or by using the `Quay Operator <https://access.redhat.com/documentation/en-us/red_hat_quay/3.5/html/deploy_red_hat_quay_on_openshift_with_the_quay_operator/>`__.
+  If you need additional assistance selecting and installing a registry, contact your sales representative or Red Hat support.
+  For more information, refer to `About disconnected install mirroring <https://docs.openshift.com/container-platform/latest/installing/disconnected_install/index.html>`__
+  in the Red Hat OpenShift Container Platform documentation.
 
-   .. note::
+  .. note::
 
-      When creating a self-signed certificate and if you enable HTTPS for the local registry, ensure you have appended ``-addext "subjectAltName=DNS:${JUMP_HOST}"`` to your ``openssl`` command, otherwise OpenShift Container Platform cannot pull images from the private registry.
+    When creating a self-signed certificate and if you enable HTTPS for the local registry, ensure you have appended ``-addext "subjectAltName=DNS:${JUMP_HOST}"`` to your ``openssl`` command, otherwise OpenShift Container Platform cannot pull images from the private registry.
 
-      If you do not set a Subject Alternative Name, before running the ``oc`` commands in the subsequent sections export the environment variable ``GODEBUG=x509ignoreCN=0``. If you do not set this variable, the ``oc`` commands will fail with the following error:
+    If you do not set a Subject Alternative Name, before running the ``oc`` commands in the subsequent sections export the environment variable ``GODEBUG=x509ignoreCN=0``. If you do not set this variable, the ``oc`` commands will fail with the following error:
 
-   .. code-block:: console
+  .. code-block:: console
 
-      $ x509: certificate relies on legacy Common Name field, use SANs or temporarily enable Common Name matching with ``GODEBUG=x509ignoreCN=0``.
+    $ x509: certificate relies on legacy Common Name field, use SANs or temporarily enable Common Name matching with ``GODEBUG=x509ignoreCN=0``.
 
-   .. note::
+  .. note::
 
-      If you use HTTP, in Openshift Container Platform add ``insecureRegistries`` to ``image.config.openshift.io/cluster``. Guidance on that configuration is provided `here <https://docs.openshift.com/container-platform/latest/openshift_images/image-configuration.html>`__.
+    If you use HTTP, in Openshift Container Platform add ``insecureRegistries`` to ``image.config.openshift.io/cluster``. Guidance on that configuration is provided `here <https://docs.openshift.com/container-platform/latest/openshift_images/image-configuration.html>`__.
 
 **On the jump host:**
 
@@ -639,10 +642,10 @@ Operator catalogs that source content provided by Red Hat and community projects
 
 * Disable the sources for the default catalogs by adding ``disableAllDefaultSources: true`` to the OperatorHub object:
 
-   .. code-block:: console
+  .. code-block:: console
 
       $ oc patch OperatorHub cluster --type json \
-          -p '[{"op": "add", "path": "/spec/disableAllDefaultSources", "value": true}]'
+         -p '[{"op": "add", "path": "/spec/disableAllDefaultSources", "value": true}]'
 
 
 **************************************************************************

--- a/openshift/mirror-gpu-ocp-disconnected.rst
+++ b/openshift/mirror-gpu-ocp-disconnected.rst
@@ -230,9 +230,9 @@ Follow the guidance below to sync the required ``yum`` repositories:
 
 #. Run ``reposync`` to synchronize the AppStream repos to the locally created directory:
 
-    .. code-block:: console
+   .. code-block:: console
 
-       $ reposync --gpgcheck --repoid=rhel-8-for-x86_64-appstream-rpms \
+      $ reposync --gpgcheck --repoid=rhel-8-for-x86_64-appstream-rpms \
         --releasever=8.4 \
         --download-path=/opt/mirror-repos/ \
         --downloadcomps \
@@ -908,7 +908,7 @@ Mirror the GPU CatalogSource
      * Set ``catalog`` to ``registry.redhat.io/redhat/redhat-operator-index:v4.12``.
      * Set ``packages`` ``name`` to ``gpu-operator-certified``.
 
-     .. code-block:: yaml
+       .. code-block:: yaml
 
         kind: ImageSetConfiguration
         apiVersion: mirror.openshift.io/v1alpha2

--- a/openshift/mirror-gpu-ocp-disconnected.rst
+++ b/openshift/mirror-gpu-ocp-disconnected.rst
@@ -67,17 +67,17 @@ Prerequisites
 
   .. note::
 
-    When creating a self-signed certificate and if you enable HTTPS for the local registry, ensure you have appended ``-addext "subjectAltName=DNS:${JUMP_HOST}"`` to your ``openssl`` command, otherwise OpenShift Container Platform cannot pull images from the private registry.
+      When creating a self-signed certificate and if you enable HTTPS for the local registry, ensure you have appended ``-addext "subjectAltName=DNS:${JUMP_HOST}"`` to your ``openssl`` command, otherwise OpenShift Container Platform cannot pull images from the private registry.
 
-    If you do not set a Subject Alternative Name, before running the ``oc`` commands in the subsequent sections export the environment variable ``GODEBUG=x509ignoreCN=0``. If you do not set this variable, the ``oc`` commands will fail with the following error:
+      If you do not set a Subject Alternative Name, before running the ``oc`` commands in the subsequent sections export the environment variable ``GODEBUG=x509ignoreCN=0``. If you do not set this variable, the ``oc`` commands will fail with the following error:
 
-  .. code-block:: console
+      .. code-block:: console
 
-    $ x509: certificate relies on legacy Common Name field, use SANs or temporarily enable Common Name matching with ``GODEBUG=x509ignoreCN=0``.
+         $ x509: certificate relies on legacy Common Name field, use SANs or temporarily enable Common Name matching with ``GODEBUG=x509ignoreCN=0``.
 
   .. note::
 
-    If you use HTTP, in Openshift Container Platform add ``insecureRegistries`` to ``image.config.openshift.io/cluster``. Guidance on that configuration is provided `here <https://docs.openshift.com/container-platform/latest/openshift_images/image-configuration.html>`__.
+      If you use HTTP, in Openshift Container Platform add ``insecureRegistries`` to ``image.config.openshift.io/cluster``. Guidance on that configuration is provided `here <https://docs.openshift.com/container-platform/latest/openshift_images/image-configuration.html>`__.
 
 **On the jump host:**
 

--- a/openshift/mirror-gpu-ocp-disconnected.rst
+++ b/openshift/mirror-gpu-ocp-disconnected.rst
@@ -43,24 +43,24 @@ Prerequisites
 
 * A working OpenShift cluster up and running with a GPU worker node. See `OpenShift Container Platform installation <https://docs.openshift.com/container-platform/latest/installing/disconnected_install/index.html>`_ for guidance on installing OpenShift Container Platform.
 
-  .. note:: If installing the **NVIDIA GPU Operator** on OpenShift Container Platform version <``4.9.9`` you need to carry out the steps highlighted as **Optional** below. For more information see :ref:`broken driver toolkit <broken-dtk>`.
+   .. note:: If installing the **NVIDIA GPU Operator** on OpenShift Container Platform version <``4.9.9`` you need to carry out the steps highlighted as **Optional** below. For more information see :ref:`broken driver toolkit <broken-dtk>`.
 
 * Access to the cluster as a user with the ``cluster-admin`` role.
 * Access to a registry that supports `Docker v2-2 <https://docs.docker.com/registry/spec/manifest-v2-2/>`_. A private registry **must** be configured on the bastion host. This can be one of the following registries:
 
-  * `Red Hat Quay <https://www.redhat.com/en/technologies/cloud-computing/quay>`__
-  * `JFrog Artifactory <https://jfrog.com/artifactory/>`_
-  * `Sonatype Nexus Repository <https://www.sonatype.com/products/repository-oss?topnav=true>`_
-  * `Harbor <https://goharbor.io/>`_
+   * `Red Hat Quay <https://www.redhat.com/en/technologies/cloud-computing/quay>`__
+   * `JFrog Artifactory <https://jfrog.com/artifactory/>`_
+   * `Sonatype Nexus Repository <https://www.sonatype.com/products/repository-oss?topnav=true>`_
+   * `Harbor <https://goharbor.io/>`_
 
-  Create a private registry using ``podman`` and guidance on this can be found `here <https://www.redhat.com/sysadmin/simple-container-registry>`__ and in the section :ref:`Creating a private registry`.
+   Create a private registry using ``podman`` and guidance on this can be found `here <https://www.redhat.com/sysadmin/simple-container-registry>`__ and in the section :ref:`Creating a private registry`.
 
-  If you have an entitlement to Red Hat Quay, see the documentation on deploying Red Hat Quay for
-  `proof-of-concept purposes <https://access.redhat.com/documentation/en-us/red_hat_quay/3.5/html/deploy_red_hat_quay_for_proof-of-concept_non-production_purposes/>`__
-  or by using the `Quay Operator <https://access.redhat.com/documentation/en-us/red_hat_quay/3.5/html/deploy_red_hat_quay_on_openshift_with_the_quay_operator/>`__.
-  If you need additional assistance selecting and installing a registry, contact your sales representative or Red Hat support.
-  For more information, refer to `About disconnected install mirroring <https://docs.openshift.com/container-platform/latest/installing/disconnected_install/index.html>`__
-  in the Red Hat OpenShift Container Platform documentation.
+   If you have an entitlement to Red Hat Quay, see the documentation on deploying Red Hat Quay for
+   `proof-of-concept purposes <https://access.redhat.com/documentation/en-us/red_hat_quay/3.5/html/deploy_red_hat_quay_for_proof-of-concept_non-production_purposes/>`__
+   or by using the `Quay Operator <https://access.redhat.com/documentation/en-us/red_hat_quay/3.5/html/deploy_red_hat_quay_on_openshift_with_the_quay_operator/>`__.
+   If you need additional assistance selecting and installing a registry, contact your sales representative or Red Hat support.
+   For more information, refer to `About disconnected install mirroring <https://docs.openshift.com/container-platform/latest/installing/disconnected_install/index.html>`__
+   in the Red Hat OpenShift Container Platform documentation.
 
    .. note::
 
@@ -71,7 +71,6 @@ Prerequisites
    .. code-block:: console
 
       $ x509: certificate relies on legacy Common Name field, use SANs or temporarily enable Common Name matching with ``GODEBUG=x509ignoreCN=0``.
-
 
    .. note::
 
@@ -325,26 +324,26 @@ Configure a private registry on the the jump host, using the following steps:
 
    At the prompts, provide the required values for the certificate:
 
-         +-----------------------------------------------------+--------------------------------------------------------------------------------------------------+
-         |       Field                                         |             Description                                                                          |
-         +=====================================================+==================================================================================================+
-         | Country Name (2 letter code)                        | Specify the two-letter ISO country code for your location.                                       |
-         |                                                     | See the `ISO 3166 country codes standard <https://www.iso.org/iso-3166-country-codes.html>`_.    |
-         +-----------------------------------------------------+--------------------------------------------------------------------------------------------------+
-         | State or Province Name (full name)                  | Enter the full name of your state or province.                                                   |
-         +-----------------------------------------------------+--------------------------------------------------------------------------------------------------+
-         | Locality Name (eg, city)                            | Enter the name of your city.                                                                     |
-         +-----------------------------------------------------+--------------------------------------------------------------------------------------------------+
-         | Organization Name (eg, company)                     | Enter your company name.                                                                         |
-         +-----------------------------------------------------+--------------------------------------------------------------------------------------------------+
-         | Organizational Unit Name (eg, section)              | Enter your department name.                                                                      |
-         +-----------------------------------------------------+--------------------------------------------------------------------------------------------------+
-         |Common Name (eg, your name or your server’s hostname)| Enter the hostname for the registry host.                                                        |
-         |                                                     | Ensure that your hostname is in DNS and that it resolves to the expected IP address.             |
-         +-----------------------------------------------------+--------------------------------------------------------------------------------------------------+
-         | Email Address                                       | For more information, see the `req                                                               |
-         |                                                     | <https://www.openssl.org/docs/man1.1.1/man1/req.html>`_ description in the OpenSSL documentation.|
-         +-----------------------------------------------------+--------------------------------------------------------------------------------------------------+
+   +-----------------------------------------------------+--------------------------------------------------------------------------------------------------+
+   |       Field                                         |             Description                                                                          |
+   +=====================================================+==================================================================================================+
+   | Country Name (2 letter code)                        | Specify the two-letter ISO country code for your location.                                       |
+   |                                                     | See the `ISO 3166 country codes standard <https://www.iso.org/iso-3166-country-codes.html>`_.    |
+   +-----------------------------------------------------+--------------------------------------------------------------------------------------------------+
+   | State or Province Name (full name)                  | Enter the full name of your state or province.                                                   |
+   +-----------------------------------------------------+--------------------------------------------------------------------------------------------------+
+   | Locality Name (eg, city)                            | Enter the name of your city.                                                                     |
+   +-----------------------------------------------------+--------------------------------------------------------------------------------------------------+
+   | Organization Name (eg, company)                     | Enter your company name.                                                                         |
+   +-----------------------------------------------------+--------------------------------------------------------------------------------------------------+
+   | Organizational Unit Name (eg, section)              | Enter your department name.                                                                      |
+   +-----------------------------------------------------+--------------------------------------------------------------------------------------------------+
+   |Common Name (eg, your name or your server’s hostname)| Enter the hostname for the registry host.                                                        |
+   |                                                     | Ensure that your hostname is in DNS and that it resolves to the expected IP address.             |
+   +-----------------------------------------------------+--------------------------------------------------------------------------------------------------+
+   | Email Address                                       | For more information, see the `req                                                               |
+   |                                                     | <https://www.openssl.org/docs/man1.1.1/man1/req.html>`_ description in the OpenSSL documentation.|
+   +-----------------------------------------------------+--------------------------------------------------------------------------------------------------+
 
 #. Generate a ``user name`` and a ``password`` for your registry that uses the ``bcrpt`` format:
 
@@ -501,9 +500,9 @@ Configuring credentials that allow images to be mirrored
 
 Create a container image registry credentials file that allows mirroring images from Red Hat to your mirror registry.
 
-  .. warning:: Do not use this image registry credentials file as the pull secret when you install a cluster. If you provide this file when you install cluster, all of the machines in the cluster will have write access to your mirror registry.
+.. warning:: Do not use this image registry credentials file as the pull secret when you install a cluster. If you provide this file when you install cluster, all of the machines in the cluster will have write access to your mirror registry.
 
-  .. warning:: This process requires that you have write access to a container image registry on the mirror registry and adds the credentials to a registry pull secret.
+.. warning:: This process requires that you have write access to a container image registry on the mirror registry and adds the credentials to a registry pull secret.
 
 #. Download your pull secret from the `Pull Secret <https://console.redhat.com/openshift/install/pull-secret>`_ page on the Red Hat OpenShift Cluster Manager site.
 

--- a/openshift/nvaie-with-ocp.rst
+++ b/openshift/nvaie-with-ocp.rst
@@ -61,37 +61,37 @@ Red Hat OpenShift on VMware vSphere
 
 Follow the steps outlined in the `Installing vSphere section <https://docs.openshift.com/container-platform/latest/installing/installing_vsphere/preparing-to-install-on-vsphere.html>`_ of the RedHat OpenShift documentation installing OpenShift on vSphere.
 
-   .. note::
-      When using virtualized GPUs you must change the boot method of each VM that is deployed as a worker and the VM template to be EFI.
-      This requires powering down running worker VMs. The template must be converted to a VM, then change the boot method to EFI, then convert back
-      to a template.
+.. note::
+   When using virtualized GPUs you must change the boot method of each VM that is deployed as a worker and the VM template to be EFI.
+   This requires powering down running worker VMs. The template must be converted to a VM, then change the boot method to EFI, then convert back
+   to a template.
 
-      Secure boot also needs to be disabled as shown:
+   Secure boot also needs to be disabled as shown:
 
-      .. image:: graphics/vmx_secure_boot.png
+   .. image:: graphics/vmx_secure_boot.png
 
-      When using the `UPI install method <https://docs.openshift.com/container-platform/latest/installing/installing_vsphere/installing-vsphere.html#installation-vsphere-machines_installing-vsphere>`_, after **Step 8** of the “Installing RHCOS and starting the OpenShift
-      Container Platform bootstrap process” change the boot method to EFI before **continuing to Step 9**.
+   When using the `UPI install method <https://docs.openshift.com/container-platform/latest/installing/installing_vsphere/installing-vsphere.html#installation-vsphere-machines_installing-vsphere>`_, after **Step 8** of the “Installing RHCOS and starting the OpenShift
+   Container Platform bootstrap process” change the boot method to EFI before **continuing to Step 9**.
 
-      When using the IPI method, each VM’s boot method can be changed to EFI after VM deployment.
+   When using the IPI method, each VM’s boot method can be changed to EFI after VM deployment.
 
-      In addition to the EFI boot setting, ensure that the VM has the following configuration parameters set:
+   In addition to the EFI boot setting, ensure that the VM has the following configuration parameters set:
 
-      **VM Settings** > **VM options** > **Advanced** > **Configuration Parameters** > **Edit Configuration**
+   **VM Settings** > **VM options** > **Advanced** > **Configuration Parameters** > **Edit Configuration**
 
-      ``pciPassthru.use64bitMMIO TRUE``
+   ``pciPassthru.use64bitMMIO TRUE``
 
-      ``pciPassthru.64bitMMIOSizeGB 512``
+   ``pciPassthru.64bitMMIOSizeGB 512``
 
-      .. image:: graphics/pci_passthrough.png
+   .. image:: graphics/pci_passthrough.png
 
-      To support GPUDirect RDMA ensure that the VM has the following configuration parameters set:
+   To support GPUDirect RDMA ensure that the VM has the following configuration parameters set:
 
-      **VM Settings** > **VM options** > **Advanced** > **Configuration Parameters** > **Edit Configuration**
+   **VM Settings** > **VM options** > **Advanced** > **Configuration Parameters** > **Edit Configuration**
 
-      ``pciPassthru.allowP2P = true``
+   ``pciPassthru.allowP2P = true``
 
-      ``pciPassthru.RelaxACSforP2P = true``
+   ``pciPassthru.RelaxACSforP2P = true``
 
 It is also recommended that you reference `Running Red Hat OpenShift Container Platform on VMware Cloud Foundation <https://core.vmware.com/resource/running-red-hat-openshift-container-platform-vmware-cloud-foundation#executive-summary>`_ documentation for deployment best practices, system configuration, and reference architecture.
 
@@ -131,17 +131,17 @@ NGC container registry).
 
 #. Enter the following into each field:
 
-    * **Secret name**: ngc-secret
+   * **Secret name**: ngc-secret
 
-    * **Authentication type**: Image registry credentials
+   * **Authentication type**: Image registry credentials
 
-    * **Registry server address**: ``nvcr.io/nvidia/vgpu``
+   * **Registry server address**: ``nvcr.io/nvidia/vgpu``
 
-    * **Username**: ``$oauthtoken``
+   * **Username**: ``$oauthtoken``
 
-    * **Password**: ``<NGC-API-KEY>``
+   * **Password**: ``<NGC-API-KEY>``
 
-    * **Email**: ``<YOUR-EMAIL>``
+   * **Email**: ``<YOUR-EMAIL>``
 
    .. image:: graphics/secrets_2.png
 
@@ -245,29 +245,29 @@ The status of the newly deployed ClusterPolicy *gpu-cluster-policy* for the NVID
 
 Verify the ClusterPolicy installation by running the following command that displays the node names and GPU counts:
 
-   .. code-block:: console
+.. code-block:: console
 
-      $ oc get nodes -o=custom-columns='Node:metadata.name,GPUs:status.capacity.nvidia\.com/gpu'
+   $ oc get nodes -o=custom-columns='Node:metadata.name,GPUs:status.capacity.nvidia\.com/gpu'
 
-   *Example Output*
+*Example Output*
 
-   .. code-block:: console
+.. code-block:: console
 
-        Node GPUs
+      Node GPUs
 
-        nvaie-ocp-7rfr8-master-0 <none>
+      nvaie-ocp-7rfr8-master-0 <none>
 
-        nvaie-ocp-7rfr8-master-1 <none>
+      nvaie-ocp-7rfr8-master-1 <none>
 
-        nvaie-ocp-7rfr8-master-2 <none>
+      nvaie-ocp-7rfr8-master-2 <none>
 
-        nvaie-ocp-7rfr8-worker-7x5km 1
+      nvaie-ocp-7rfr8-worker-7x5km 1
 
-        nvaie-ocp-7rfr8-worker-9jgmk <none>
+      nvaie-ocp-7rfr8-worker-9jgmk <none>
 
-        nvaie-ocp-7rfr8-worker-jntsp 1
+      nvaie-ocp-7rfr8-worker-jntsp 1
 
-        nvaie-ocp-7rfr8-worker-zkggt <none>
+      nvaie-ocp-7rfr8-worker-zkggt <none>
 
 
 Verify the successful installation of the NVIDIA GPU Operator

--- a/openshift/nvaie-with-ocp.rst
+++ b/openshift/nvaie-with-ocp.rst
@@ -68,7 +68,7 @@ Follow the steps outlined in the `Installing vSphere section <https://docs.opens
 
       Secure boot also needs to be disabled as shown:
 
-        .. image:: graphics/vmx_secure_boot.png
+      .. image:: graphics/vmx_secure_boot.png
 
       When using the `UPI install method <https://docs.openshift.com/container-platform/latest/installing/installing_vsphere/installing-vsphere.html#installation-vsphere-machines_installing-vsphere>`_, after **Step 8** of the “Installing RHCOS and starting the OpenShift
       Container Platform bootstrap process” change the boot method to EFI before **continuing to Step 9**.
@@ -83,7 +83,7 @@ Follow the steps outlined in the `Installing vSphere section <https://docs.opens
 
       ``pciPassthru.64bitMMIOSizeGB 512``
 
-         .. image:: graphics/pci_passthrough.png
+      .. image:: graphics/pci_passthrough.png
 
       To support GPUDirect RDMA ensure that the VM has the following configuration parameters set:
 

--- a/openshift/openshift-virtualization.rst
+++ b/openshift/openshift-virtualization.rst
@@ -232,9 +232,12 @@ Use the following steps to build the vGPU Manager container and push it to a pri
      Confirm that the **Product Version** column shows the vGPU version to install.
      Unzip the bundle to obtain the NVIDIA vGPU Manager for Linux file, ``NVIDIA-Linux-x86_64-<version>-vgpu-kvm.run``.
 
-      .. include:: ../gpu-operator/gpu-operator-kubevirt.rst
-         :start-after: start-nvaie-run-file
-         :end-before: end-nvaie-run-file
+     .. note::
+
+         NVIDIA AI Enterprise customers must use the ``aie`` .run file for building the NVIDIA vGPU Manager image.
+         Download the ``NVIDIA-Linux-x86_64-<version>-vgpu-kvm-aie.run`` file instead, and rename it to
+         ``NVIDIA-Linux-x86_64-<version>-vgpu-kvm.run`` before proceeding with the rest of the procedure.
+         Refer to the ``Infrastructure Support Matrix`` under section under the `NVIDIA AI Enterprise Infra Release Branches <https://docs.nvidia.com/ai-enterprise/index.html#infrastructure-software>`_ for details on supported version number to use. 
 
    Use the following steps to clone the driver container repository and build the driver image.
 
@@ -317,17 +320,17 @@ private container registry).
 
 #. Enter the following into each field:
 
-    * **Secret name**: private-registry-secret
+   * **Secret name**: private-registry-secret
 
-    * **Authentication type**: Image registry credentials
+   * **Authentication type**: Image registry credentials
 
-    * **Registry server address**: <private-registry_address>
+   * **Registry server address**: <private-registry_address>
 
-    * **Username**: $oauthtoken
+   * **Username**: $oauthtoken
 
-    * **Password**: <API-KEY>
+   * **Password**: <API-KEY>
 
-    * **Email**: <YOUR-EMAIL>
+   * **Email**: <YOUR-EMAIL>
 
 #. Click **Create**.
 
@@ -655,9 +658,9 @@ For example, the ``default`` configuration will create two **A10-12Q** devices o
 
 If custom vGPU device configuration is desired, more than the default ConfigMap provides, you can create your own ConfigMap:
 
-   .. code-block:: console
+.. code-block:: console
 
-       $ oc create configmap custom-vgpu-config -n gpu-operator --from-file=config.yaml=/path/to/file
+      $ oc create configmap custom-vgpu-config -n gpu-operator --from-file=config.yaml=/path/to/file
 
 And then configure the GPU Operator to use it by setting ``vgpuDeviceManager.config.name=custom-vgpu-config``.
 
@@ -673,44 +676,44 @@ To apply a new configuration after GPU Operator install, simply update the ``nvi
 
 Let's run through an example on a system with two **A10** GPUs.
 
-   .. code-block:: console
+.. code-block:: console
 
-      $ nvidia-smi -L
-      GPU 0: NVIDIA A10 (UUID: GPU-ebd34bdf-1083-eaac-2aff-4b71a022f9bd)
-      GPU 1: NVIDIA A10 (UUID: GPU-1795e88b-3395-b27b-dad8-0488474eec0c)
+   $ nvidia-smi -L
+   GPU 0: NVIDIA A10 (UUID: GPU-ebd34bdf-1083-eaac-2aff-4b71a022f9bd)
+   GPU 1: NVIDIA A10 (UUID: GPU-1795e88b-3395-b27b-dad8-0488474eec0c)
 
 After installing the GPU Operator as detailed in the previous sections and without labeling the node with ``nvidia.com/vgpu.config``, the ``default`` vGPU config get applied -- four **A10-12Q** devices get created (two per GPU):
 
-   .. code-block:: console
+.. code-block:: console
 
-      $ oc get node cnt-server-2 -o json | jq '.status.allocatable | with_entries(select(.key | startswith("nvidia.com/"))) | with_entries(select(.value != "0"))'
-      {
-        "nvidia.com/NVIDIA_A10-12Q": "4"
-      }
+   $ oc get node cnt-server-2 -o json | jq '.status.allocatable | with_entries(select(.key | startswith("nvidia.com/"))) | with_entries(select(.value != "0"))'
+   {
+      "nvidia.com/NVIDIA_A10-12Q": "4"
+   }
 
 If instead you want to create **A10-4Q** devices, we can label the node like such:
 
-   .. code-block:: console
+.. code-block:: console
 
-      $ oc label node <node-name> --overwrite nvidia.com/vgpu.config=A10-4Q
+   $ oc label node <node-name> --overwrite nvidia.com/vgpu.config=A10-4Q
 
 After the vGPU Device Manager finishes applying the new configuration, all GPU Operator pods should return to the Running state.
 
-   .. code-block:: console
+.. code-block:: console
 
-      $ oc get pods -n gpu-operator
-      NAME                                                          READY   STATUS    RESTARTS   AGE
-      ...
-      nvidia-sandbox-device-plugin-daemonset-brtb6                  1/1     Running   0          10s
-      nvidia-sandbox-validator-ljnwg                                1/1     Running   0          10s
-      nvidia-vgpu-device-manager-8mgg8                              1/1     Running   0          30m
-      nvidia-vgpu-manager-daemonset-fpplc                           1/1     Running   0          31m
+   $ oc get pods -n gpu-operator
+   NAME                                                          READY   STATUS    RESTARTS   AGE
+   ...
+   nvidia-sandbox-device-plugin-daemonset-brtb6                  1/1     Running   0          10s
+   nvidia-sandbox-validator-ljnwg                                1/1     Running   0          10s
+   nvidia-vgpu-device-manager-8mgg8                              1/1     Running   0          30m
+   nvidia-vgpu-manager-daemonset-fpplc                           1/1     Running   0          31m
 
 You should now see 12 **A10-4Q** devices on the node, as 6 **A10-4Q** devices can be created per **A10** GPU.
 
-   .. code-block:: console
+.. code-block:: console
 
-      $ oc get node cnt-server-2 -o json | jq '.status.allocatable | with_entries(select(.key | startswith("nvidia.com/"))) | with_entries(select(.value != "0"))'
-      {
-        "nvidia.com/NVIDIA_A10-4Q": "12"
-      }
+   $ oc get node cnt-server-2 -o json | jq '.status.allocatable | with_entries(select(.key | startswith("nvidia.com/"))) | with_entries(select(.value != "0"))'
+   {
+      "nvidia.com/NVIDIA_A10-4Q": "12"
+   }

--- a/openshift/openshift-virtualization.rst
+++ b/openshift/openshift-virtualization.rst
@@ -118,13 +118,13 @@ Prerequisites
      hyperconverged.hco.kubevirt.io/kubevirt-hyperconverged patched
 
 
-* If planning to use NVIDIA vGPU, SR-IOV must be enabled in the BIOS if your GPUs are based on the NVIDIA Ampere architecture or later. Refer to the `NVIDIA vGPU Documentation <https://docs.nvidia.com/grid/latest/grid-vgpu-user-guide/index.html#prereqs-vgpu>`_ to ensure you have met all of the prerequisites for using NVIDIA vGPU.
+* If planning to use NVIDIA vGPU, SR-IOV must be enabled in the BIOS if your GPUs are based on the NVIDIA Ampere architecture or later. Refer to the `NVIDIA vGPU Documentation <https://docs.nvidia.com/grid/latest/grid-vgpu-user-guide/index.html#prereqs-vgpu>`_ to ensure you have met all the prerequisites for using NVIDIA vGPU.
 
 ***********************************************************
 Configure NVIDIA GPU Operator with OpenShift Virtualization
 ***********************************************************
 
-After configuring the :ref:`prerequisites<prerequisites>`, the high level workflow for using the NVIDIA GPU Operator with OpenShift Virtualization is as follows:
+After configuring the :ref:`prerequisites<prerequisites>`, the high-level workflow for using the NVIDIA GPU Operator with OpenShift Virtualization is as follows:
 
 * :ref:`Enable the IOMMU driver <enable-iommu-driver>`.
 * :ref:`Label worker nodes <label-worker-nodes>` based on the GPU workloads they will run.
@@ -161,7 +161,7 @@ Procedure
 =========
 
 #. Create a ``MachineConfig`` object that identifies the kernel argument.
-   The following example shows a kernel argument for an Intel CPU:
+   The following example shows a kernel argument for an Intel CPU.
 
    .. code-block:: yaml
 
@@ -180,13 +180,13 @@ Procedure
             # If you are using AMD CPU, include the following argument:
             # - amd_iommu=on
 
-#. Create the new ``MachineConfig`` object:
+#. Create the new ``MachineConfig`` object.
 
    .. code-block:: console
 
       $ oc create -f 100-worker-kernel-arg-iommu.yaml
 
-#. Verify that the new ``MachineConfig`` object was added:
+#. Verify that the new ``MachineConfig`` object was added.
 
    .. code-block:: console
 
@@ -199,7 +199,7 @@ Procedure
 Labeling worker nodes
 *********************
 
-Use the following command to add a label to a worker node:
+Use the following command to add a label to a worker node.
 
 .. code-block:: console
 
@@ -214,7 +214,7 @@ To change the default GPU workload configuration, set the following value in ``C
 .. _build-vgpu-manager-image:
 
 *******************************
-Building the vGPU Manager image
+Building the vGPU Manager Image
 *******************************
 
 .. note::
@@ -232,9 +232,9 @@ Use the following steps to build the vGPU Manager container and push it to a pri
      Confirm that the **Product Version** column shows the vGPU version to install.
      Unzip the bundle to obtain the NVIDIA vGPU Manager for Linux file, ``NVIDIA-Linux-x86_64-<version>-vgpu-kvm.run``.
 
-   .. include:: ../gpu-operator/gpu-operator-kubevirt.rst
-      :start-after: start-nvaie-run-file
-      :end-before: end-nvaie-run-file
+      .. include:: ../gpu-operator/gpu-operator-kubevirt.rst
+         :start-after: start-nvaie-run-file
+         :end-before: end-nvaie-run-file
 
    Use the following steps to clone the driver container repository and build the driver image.
 
@@ -257,7 +257,7 @@ Use the following steps to build the vGPU Manager container and push it to a pri
 
       $ cp <local-driver-download-directory>/*-vgpu-kvm.run ./
 
-#. Set the following environment variables:
+#. Set the following environment variables.
 
    * ``PRIVATE_REGISTRY`` - Name of the private registry used to store the driver image.
    * ``VERSION`` - The NVIDIA vGPU Manager version downloaded from the NVIDIA Software Portal.
@@ -271,9 +271,9 @@ Use the following steps to build the vGPU Manager container and push it to a pri
 .. note::
 
    The recommended registry to use is the Integrated OpenShift Container Platform registry.
-   For more information about the registry, see `Accessing the registry <https://docs.openshift.com/container-platform/latest/registry/accessing-the-registry.html>`_.
+   For more information about the registry, refer to `Accessing the registry <https://docs.openshift.com/container-platform/latest/registry/accessing-the-registry.html>`_.
 
-#. Build the NVIDIA vGPU Manager image:
+#. Build the NVIDIA vGPU Manager image.
 
    .. code-block:: console
 
@@ -281,7 +281,7 @@ Use the following steps to build the vGPU Manager container and push it to a pri
           --build-arg DRIVER_VERSION=${VERSION} \
           -t ${PRIVATE_REGISTRY}/vgpu-manager:${VERSION}-${OS_TAG} .
 
-#. Push the NVIDIA vGPU Manager image to your private registry:
+#. Push the NVIDIA vGPU Manager image to your private registry.
 
    .. code-block:: console
 
@@ -365,7 +365,7 @@ Create the cluster policy using the CLI:
 
    In general, the flag ``sandboxWorkloads.enabled`` in ``ClusterPolicy`` controls whether the GPU Operator can provision GPU worker nodes for virtual machine workloads, in addition to container workloads. This flag is disabled by default, meaning all nodes get provisioned with the same software which enables container workloads, and the ``nvidia.com/gpu.workload.config`` node label is not used.
 
-   The term ``sandboxing`` refers to running software in a separate isolated environment, typically for added security (i.e. a virtual machine). We use the term ``sandbox workloads`` to signify workloads that run in a virtual machine, irrespective of the virtualization technology used.
+   The term ``sandboxing`` refers to running software in a separate isolated environment, typically for added security (i.e. a virtual machine). The term ``sandbox workloads`` signifies workloads that run in a virtual machine, regardless of the virtualization technology used.
 
 
 #. Apply the changes:
@@ -406,7 +406,7 @@ As a cluster administrator, you can create a ClusterPolicy using the OpenShift C
 
    In general, when sandbox workloads are enabled, ``ClusterPolicy`` controls whether the GPU Operator can provision GPU worker nodes for virtual machine workloads, in addition to container workloads. This flag is disabled by default, meaning all nodes get provisioned with the same software which enables container workloads, and the ``nvidia.com/gpu.workload.config`` node label is not used.
 
-   The term ``sandboxing`` refers to running software in a separate isolated environment, typically for added security (i.e. a virtual machine). We use the term ``sandbox workloads`` to signify workloads that run in a virtual machine, irrespective of the virtualization technology used.
+   The term ``sandboxing`` refers to running software in a separate isolated environment, typically for added security (i.e. a virtual machine). The term ``sandbox workloads`` signifies workloads that run in a virtual machine, regardless of the virtualization technology used.
    * Click **Create** to create the ClusterPolicy.
 
    .. image:: graphics/cluster_policy_enable_sandbox_workloads.png
@@ -449,7 +449,7 @@ Add GPU passthrough resources to the HyperConverged Custom Resource
 
 The following example permits the A10 GPU device, the device names for the GPUs on your cluster will likely be different.
 
-#. Determine the resource names for the GPU devices:
+#. Determine the resource names for the GPU devices.
 
    .. code-block:: console
 
@@ -457,7 +457,7 @@ The following example permits the A10 GPU device, the device names for the GPUs 
 
    *Example Output*
 
-   .. code-blocK:: output
+   .. code-block:: output
 
       {
         "nvidia.com/GA102GL_A10": "1"
@@ -497,7 +497,7 @@ The following example permits the A10 GPU device, the device names for the GPUs 
               resourceName: nvidia.com/GA102GL_A10
       ...
 
-   Replace the values in the YAML as follows:
+   Replace the values in the YAML as follows.
 
    * ``pciDeviceSelector`` and ``resourceName`` under ``pciHostDevices`` to correspond to your GPU type.
 
@@ -512,7 +512,7 @@ Add vGPU resources to the HyperConverged Custom Resource
 
 The following example permits the A10-12Q vGPU device, the device names for the GPUs on your cluster will likely be different.
 
-#. Determine the resource names for the GPU devices:
+#. Determine the resource names for the GPU devices.
 
    .. code-block:: console
 
@@ -520,7 +520,7 @@ The following example permits the A10-12Q vGPU device, the device names for the 
 
    *Example Output*
 
-   .. code-blocK:: output
+   .. code-block:: output
 
       {
         "nvidia.com/NVIDIA_A10-12Q": "4"
@@ -560,7 +560,7 @@ The following example permits the A10-12Q vGPU device, the device names for the 
             resourceName: nvidia.com/NVIDIA_A10-12Q
       ...
 
-   Replace the values in the YAML as follows:
+   Replace the values in the YAML as follows.
 
    * ``mdevNameSelector`` and ``resourceName`` under ``mediatedDevices`` to correspond to your vGPU type.
 

--- a/openshift/prerequisites.rst
+++ b/openshift/prerequisites.rst
@@ -7,7 +7,7 @@ Prerequisites for GPU Operator on OpenShift
 
 Before following the steps in this guide, ensure that your environment has:
 
-* A working OpenShift cluster up and running with a GPU worker node. See `OpenShift Container Platform installation <https://docs.redhat.com/en/documentation/openshift_container_platform/latest/html/installation_overview/ocp-installation-overview>`_  for guidance on installing.
+* A working OpenShift cluster up and running with a GPU worker node. Refer to the `OpenShift Container Platform installation overview <https://docs.redhat.com/en/documentation/openshift_container_platform/latest/html/installation_overview/ocp-installation-overview>`_ for installation guidance.
   Refer to :external+gpuop:ref:`Container Platforms <container-platforms>` for the support matrix of the GPU Operator releases and the supported container platforms for more information.
 * Access to the OpenShift cluster as a ``cluster-admin`` to perform the necessary steps.
 * OpenShift CLI (``oc``) installed.

--- a/openshift/time-slicing-gpus-in-openshift.rst
+++ b/openshift/time-slicing-gpus-in-openshift.rst
@@ -148,51 +148,51 @@ Creating the slicing configurations
 
    .. code-block:: yaml
 
-        version: v1
-        sharing:
-          timeSlicing:
-            renameByDefault: false
-            resources:
-              - name: nvidia.com/gpu
-                replicas: 8
+      version: v1
+      sharing:
+        timeSlicing:
+          renameByDefault: false
+          resources:
+            - name: nvidia.com/gpu
+              replicas: 8
 
 #. Verify that GFD labels have been added to indicate time-sharing.
 
    .. code-block:: console
 
       $ oc get node --selector=nvidia.com/gpu.product=Tesla-T4-SHARED -o json \
-       | jq '.items[0].metadata.labels' | grep nvidia
+        | jq '.items[0].metadata.labels' | grep nvidia
 
    **Example Output**
 
    .. code-block:: console
 
-       "nvidia.com/cuda.driver.major": "510",
-       "nvidia.com/cuda.driver.minor": "73",
-       "nvidia.com/cuda.driver.rev": "08",
-       "nvidia.com/cuda.runtime.major": "11",
-       "nvidia.com/cuda.runtime.minor": "7",
-       "nvidia.com/device-plugin.config": "Tesla-T4",
-       "nvidia.com/gfd.timestamp": "1655482336",
-       "nvidia.com/gpu.compute.major": "7",
-       "nvidia.com/gpu.compute.minor": "5",
-       "nvidia.com/gpu.count": "1",
-       "nvidia.com/gpu.deploy.container-toolkit": "true",
-       "nvidia.com/gpu.deploy.dcgm": "true",
-       "nvidia.com/gpu.deploy.dcgm-exporter": "true",
-       "nvidia.com/gpu.deploy.device-plugin": "true",
-       "nvidia.com/gpu.deploy.driver": "true",
-       "nvidia.com/gpu.deploy.gpu-feature-discovery": "true",
-       "nvidia.com/gpu.deploy.node-status-exporter": "true",
-       "nvidia.com/gpu.deploy.nvsm": "",
-       "nvidia.com/gpu.deploy.operator-validator": "true",
-       "nvidia.com/gpu.family": "turing",
-       "nvidia.com/gpu.machine": "g4dn.xlarge",
-       "nvidia.com/gpu.memory": "16106127360",
-       "nvidia.com/gpu.present": "true",
-       "nvidia.com/gpu.product": "Tesla-T4-SHARED",
-       "nvidia.com/gpu.replicas": "8",
-       "nvidia.com/mig.strategy": "single",
+      "nvidia.com/cuda.driver.major": "510",
+      "nvidia.com/cuda.driver.minor": "73",
+      "nvidia.com/cuda.driver.rev": "08",
+      "nvidia.com/cuda.runtime.major": "11",
+      "nvidia.com/cuda.runtime.minor": "7",
+      "nvidia.com/device-plugin.config": "Tesla-T4",
+      "nvidia.com/gfd.timestamp": "1655482336",
+      "nvidia.com/gpu.compute.major": "7",
+      "nvidia.com/gpu.compute.minor": "5",
+      "nvidia.com/gpu.count": "1",
+      "nvidia.com/gpu.deploy.container-toolkit": "true",
+      "nvidia.com/gpu.deploy.dcgm": "true",
+      "nvidia.com/gpu.deploy.dcgm-exporter": "true",
+      "nvidia.com/gpu.deploy.device-plugin": "true",
+      "nvidia.com/gpu.deploy.driver": "true",
+      "nvidia.com/gpu.deploy.gpu-feature-discovery": "true",
+      "nvidia.com/gpu.deploy.node-status-exporter": "true",
+      "nvidia.com/gpu.deploy.nvsm": "",
+      "nvidia.com/gpu.deploy.operator-validator": "true",
+      "nvidia.com/gpu.family": "turing",
+      "nvidia.com/gpu.machine": "g4dn.xlarge",
+      "nvidia.com/gpu.memory": "16106127360",
+      "nvidia.com/gpu.present": "true",
+      "nvidia.com/gpu.product": "Tesla-T4-SHARED",
+      "nvidia.com/gpu.replicas": "8",
+      "nvidia.com/mig.strategy": "single",
 
    If you remove the label, the node configuration is reset to its default.
 
@@ -211,11 +211,11 @@ Consider a MachineSet named ``worker-gpu-nvidia-t4-us-east-1``, with
 You want to ensure the new nodes will have time slicing enabled automatically, that is, you want to apply the
 label to every new node. This can be done by setting the label in the MachineSet template.
 
-   .. code-block:: console
+.. code-block:: console
 
-      $ oc patch machineset worker-gpu-nvidia-t4-us-east-1a \
-          -n openshift-machine-api --type merge \
-          --patch '{"spec": {"template": {"spec": {"metadata": {"labels": {"nvidia.com/device-plugin.config": "Tesla-T4"}}}}}}'
+  $ oc patch machineset worker-gpu-nvidia-t4-us-east-1a \
+      -n openshift-machine-api --type merge \
+      --patch '{"spec": {"template": {"spec": {"metadata": {"labels": {"nvidia.com/device-plugin.config": "Tesla-T4"}}}}}}'
 
 Now, any new machine created by the Machine Autoscaler for this MachineSet will have the label, and time-slicing enabled.
 

--- a/openshift/troubleshooting-gpu-ocp.rst
+++ b/openshift/troubleshooting-gpu-ocp.rst
@@ -7,12 +7,12 @@
 Troubleshooting
 *****************************************
 
-This section includes errors that users may encounter when performing various checks during installing the **NVIDIA GPU Operator** on the OpenShift Container Platform cluster.
+This section includes errors that users might encounter when performing various checks during installation of the **NVIDIA GPU Operator** on the OpenShift Container Platform cluster.
 
 Node Feature Discovery checks
 -----------------------------------
 
-#. Verify the Node Feature Discovery has been created:
+#. Verify that the Node Feature Discovery has been created.
 
    .. code-block:: console
 
@@ -25,9 +25,9 @@ Node Feature Discovery checks
 
    .. note::
 
-      If empty the Node Feature Discovery Custom Resource (CR) must be created.
+      If empty, the Node Feature Discovery Custom Resource (CR) must be created.
 
-#. Ensure there are nodes with GPU. In this example the check is performed for the NVIDIA GPU which uses the PCI ID 10de.
+#. Ensure that there are nodes with GPUs. In this example, the check is performed for the NVIDIA GPU that uses the PCI ID ``10de``.
 
    .. code-block:: console
 
@@ -41,7 +41,7 @@ Node Feature Discovery checks
 GPU Operator checks
 -------------------
 
-#. Verify the Custom Resource Definition (CRD) is deployed.
+#. Verify that the Custom Resource Definition (CRD) is deployed.
 
    .. code-block:: console
 

--- a/openshift/troubleshooting-gpu-ocp.rst
+++ b/openshift/troubleshooting-gpu-ocp.rst
@@ -109,25 +109,25 @@ Validate the GPU stack
 
 The GPU Operator validates the stack using the ``nvidia-device-plugin-validator`` and the ``nvidia-cuda-validator`` pod. If they report the status ``Completed``, the stack works as expected.
 
-   .. code-block:: console
+.. code-block:: console
 
-      $ oc get po -n nvidia-gpu-operator
+   $ oc get po -n nvidia-gpu-operator
 
-   .. code-block:: console
+.. code-block:: console
 
-      NAME                                                              READY   STATUS      RESTARTS   AGE
-      bb0dd90f1b757a8c7b338785a4a65140732d30447093bc2c4f6ae8e75844gfv   0/1     Completed   0          125m
-      gpu-feature-discovery-hlpgs                                       1/1     Running     0          122m
-      gpu-operator-8dc8d6648-jzhnr                                      1/1     Running     0          125m
-      nvidia-container-toolkit-daemonset-z2wh7                          1/1     Running     0          122m
-      nvidia-cuda-validator-8fx22                                       0/1     Completed   0          117m
-      nvidia-dcgm-exporter-ds9xd                                        1/1     Running     0          122m
-      nvidia-dcgm-k7tz6                                                 1/1     Running     0          122m
-      nvidia-device-plugin-daemonset-nqxmc                              1/1     Running     0          122m
-      nvidia-device-plugin-validator-87zdl                              0/1     Completed   0          117m
-      nvidia-driver-daemonset-48.84.202110270303-0-9df9j                2/2     Running     0          122m
-      nvidia-node-status-exporter-7bhdk                                 1/1     Running     0          122m
-      nvidia-operator-validator-kjznr                                   1/1     Running     0          122m
+   NAME                                                              READY   STATUS      RESTARTS   AGE
+   bb0dd90f1b757a8c7b338785a4a65140732d30447093bc2c4f6ae8e75844gfv   0/1     Completed   0          125m
+   gpu-feature-discovery-hlpgs                                       1/1     Running     0          122m
+   gpu-operator-8dc8d6648-jzhnr                                      1/1     Running     0          125m
+   nvidia-container-toolkit-daemonset-z2wh7                          1/1     Running     0          122m
+   nvidia-cuda-validator-8fx22                                       0/1     Completed   0          117m
+   nvidia-dcgm-exporter-ds9xd                                        1/1     Running     0          122m
+   nvidia-dcgm-k7tz6                                                 1/1     Running     0          122m
+   nvidia-device-plugin-daemonset-nqxmc                              1/1     Running     0          122m
+   nvidia-device-plugin-validator-87zdl                              0/1     Completed   0          117m
+   nvidia-driver-daemonset-48.84.202110270303-0-9df9j                2/2     Running     0          122m
+   nvidia-node-status-exporter-7bhdk                                 1/1     Running     0          122m
+   nvidia-operator-validator-kjznr                                   1/1     Running     0          122m
 
 #. Verify the cuda validator logs:
 


### PR DESCRIPTION
Several major HTML formatting issues due to RST indentation syntax mistakes.

For example, visually compare: https://docs.nvidia.com/datacenter/cloud-native/openshift/25.3.2/install-gpu-ocp.html
with preview: https://nvidia.github.io/cloud-native-docs/review/pr-255/openshift/latest/install-gpu-ocp.html

Signed-off-by: Andrew Chen <andrewch@nvidia.com>