### PR TITLE
Update supported precompiled drivers

### DIFF
--- a/gpu-operator/platform-support.rst
+++ b/gpu-operator/platform-support.rst
@@ -472,13 +472,13 @@ See the :doc:`precompiled-drivers` page for more information about using precomp
 +----------------------------+------------------------+----------------+---------------------+
 | Operating System           | Kernel Flavor          | Kernel Version | CUDA Driver Branch  |
 +============================+========================+================+=====================+
-| Ubuntu 22.04               | Generic, NVIDIA, Azure |  5.15          |  R535, R550, R570   |
+| Ubuntu 22.04               | Generic, NVIDIA, Azure |  5.15          |  R535, R570, R580   |
 |                            | AWS, Oracle            |                |                     |
 +----------------------------+------------------------+----------------+---------------------+
-| Ubuntu 22.04               | Generic, NVIDIA, Azure |  6.8           |  R535, R570         |
+| Ubuntu 22.04               | Generic, NVIDIA, Azure |  6.8           |  R535, R570, R580   |
 |                            | AWS, Oracle            |                |                     |
 +----------------------------+------------------------+----------------+---------------------+
-| Ubuntu 24.04               | Generic, NVIDIA, Azure |  6.8           |  R550, R570         |
+| Ubuntu 24.04               | Generic, NVIDIA, Azure |  6.8           |  R570, R580         |
 |                            | AWS, Oracle            |                |                     |
 +----------------------------+------------------------+----------------+---------------------+
 


### PR DESCRIPTION
Preview: https://nvidia.github.io/cloud-native-docs/review/pr-261/gpu-operator/latest/platform-support.html#supported-precompiled-drivers

## 28 artifacts published to the production NGC Catalog

nvidia/driver:535-5.15.0-1092-aws-ubuntu22.04 - image
nvidia/driver:535-6.8.0-1039-aws-ubuntu22.04 - image
nvidia/driver:535-5.15.0-1096-azure-ubuntu22.04 - image
nvidia/driver:535-5.15.0-156-generic-ubuntu22.04 - image
nvidia/driver:535-6.8.0-83-generic-ubuntu22.04 - image
nvidia/driver:535-5.15.0-1087-nvidia-ubuntu22.04 - image
nvidia/driver:535-6.8.0-1039-nvidia-ubuntu22.04 - image
nvidia/driver:535-5.15.0-1090-oracle-ubuntu22.04 - image
nvidia/driver:570-5.15.0-1092-aws-ubuntu22.04 - image
nvidia/driver:570-6.8.0-1039-aws-ubuntu22.04 - image
nvidia/driver:570-5.15.0-1096-azure-ubuntu22.04 - image
nvidia/driver:570-6.8.0-1034-azure-ubuntu22.04 - image
nvidia/driver:570-5.15.0-156-generic-ubuntu22.04 - image
nvidia/driver:570-6.8.0-83-generic-ubuntu22.04 - image
nvidia/driver:570-5.15.0-1087-nvidia-ubuntu22.04 - image
nvidia/driver:570-5.15.0-1090-oracle-ubuntu22.04 - image
nvidia/driver:570-6.8.0-1035-oracle-ubuntu22.04 - image
nvidia/driver:580-5.15.0-1092-aws-ubuntu22.04 - image
nvidia/driver:580-6.8.0-1039-aws-ubuntu22.04 - image
nvidia/driver:580-5.15.0-1096-azure-ubuntu22.04 - image
nvidia/driver:580-5.15.0-156-generic-ubuntu22.04 - image
nvidia/driver:580-5.15.0-1087-nvidia-ubuntu22.04 - image
nvidia/driver:570-6.8.0-84-generic-ubuntu24.04 - image
nvidia/driver:570-6.8.0-1039-nvidia-ubuntu24.04 - image
nvidia/driver:570-6.8.0-1035-oracle-ubuntu24.04 - image
nvidia/driver:580-6.8.0-1039-aws-ubuntu24.04 - image
nvidia/driver:580-6.8.0-84-generic-ubuntu24.04 - image
nvidia/driver:580-6.8.0-1039-nvidia-ubuntu24.04 - image

Signed-off-by: Andrew Chen <andrewch@nvidia.com>