### PR TITLE
Fix precompiled drivers limitations copy

### DIFF
--- a/gpu-operator/precompiled-drivers.rst
+++ b/gpu-operator/precompiled-drivers.rst
@@ -41,7 +41,7 @@ Limitations and Restrictions
 ============================
 
 * Support for deploying the driver containers with precompiled drivers is limited to
-  hosts with the Ubuntu 22.04 operating system and x86_64 architecture.
+  hosts with the x86_64 architecture and operating system versions listed in the `Supported Precompiled Drivers <platform-support#supported-precompiled-drivers>`_ table.
 
   For information about using precompiled drivers with OpenShift Container Platform,
   refer to :external+ocp:doc:`gpu-operator-with-precompiled-drivers`.


### PR DESCRIPTION
Remove specific reference to Ubuntu 22.04 and refer to Supported Precompiled Drivers table in the Platform Support page.

Preview: https://nvidia.github.io/cloud-native-docs/review/pr-263/gpu-operator/latest/precompiled-drivers.html#limitations-and-restrictions

Signed-off-by: Andrew Chen <andrewch@nvidia.com>