### PR TITLE
Update instructions for enabling experimental repos for deb

### DIFF
--- a/container-toolkit/install-guide.md
+++ b/container-toolkit/install-guide.md
@@ -44,7 +44,7 @@ where `systemd` cgroup drivers are used that cause containers to lose access to 
    Optionally, configure the repository to use experimental packages:
 
    ```console
-   $ sed -i -e '/experimental/ s/^#//g' /etc/apt/sources.list.d/nvidia-container-toolkit.list
+   $ sudo sed -i -e '/experimental/ s/^#//g' /etc/apt/sources.list.d/nvidia-container-toolkit.list
    ```
 
 1. Update the packages list from the repository:


### PR DESCRIPTION
The command to enable the experimental repos is missing a `sudo`.