### PR TITLE
Add RHEL10 to NVIDIA Container Toolkit support matrix

### DIFF
--- a/container-toolkit/supported-platforms.md
+++ b/container-toolkit/supported-platforms.md
@@ -17,6 +17,7 @@ Recent NVIDIA Container Toolkit releases are tested and expected to work on thes
 | CentOS 8                 | X              | X       | X                        |
 | RHEL 8.x                 | X              | X       | X                        |
 | RHEL 9.x                 | X              | X       | X                        |
+| RHEL 10.x                | X              | X       | X                        |
 | Ubuntu 20.04             | X              | X       | X                        |
 | Ubuntu 22.04             | X              | X       | X                        |
 | Ubuntu 24.04             | X              |         | X                        |


### PR DESCRIPTION
RHEL10 was validated as part of the 1.18.0 release.