### PR TITLE
fix configmap for custom-mig-config

### DIFF
--- a/gpu-operator/manifests/input/mig-cm-values.yaml
+++ b/gpu-operator/manifests/input/mig-cm-values.yaml
@@ -2,7 +2,7 @@ migManager:
   config:
     name: custom-mig-config
     create: true
-    data: |-
+    data:
       config.yaml: |-
         version: v1
         mig-configs:


### PR DESCRIPTION
This addresses https://github.com/NVIDIA/gpu-operator/issues/1259

There was a fix in gpu-operator in PR https://github.com/NVIDIA/gpu-operator/pull/1273