### PR TITLE
Highlight tag change policy for OpenShift Virtualization for OCP4.19+

### DIFF
--- a/openshift/openshift-virtualization.rst
+++ b/openshift/openshift-virtualization.rst
@@ -263,12 +263,26 @@ Use the following steps to build the vGPU Manager container and push it to a pri
    * ``PRIVATE_REGISTRY`` - Name of the private registry used to store the driver image.
    * ``VGPU_HOST_DRIVER_VERSION`` - The NVIDIA vGPU Manager version downloaded from the NVIDIA Software Portal.
    * ``OS_TAG`` - This must match the Guest OS version.
-     For RedHat OpenShift, specify ``rhcos4.x`` where _x_ is the supported minor OCP version.
+
+.. note::
+   The driver container image tag for OpenShift has changed after the OCP 4.19 release.
+   Refer to `OpenShift Container Platform 4.19 Release Notes section 1.4.5 <https://docs.redhat.com/en/documentation/openshift_container_platform/4.19/html/release_notes/ocp-4-19-release-notes#ocp-4-19-rhcos-split-layers_release-notes>`_,
+   `RHEL Versions Utilized by RHEL CoreOS and OCP <https://access.redhat.com/articles/6907891>`_,
+   and `Split RHCOS into layers: /etc/os-release <https://github.com/openshift/enhancements/blob/master/enhancements/rhcos/split-rhcos-into-layers.md#etcos-release>`_
+   for more information.
+
+
+   For RedHat OpenShift 4.18 or earlier, specify ``rhcos4.x`` where _x_ is the supported minor OCP version.
 
    .. code-block:: console
 
-      $ export PRIVATE_REGISTRY=my/private/registry VGPU_HOST_DRIVER_VERSION=580.82.07 OS_TAG=rhcos4.18
+         $ export PRIVATE_REGISTRY=my/private/registry VGPU_HOST_DRIVER_VERSION=580.82.07 OS_TAG=rhcos4.18
 
+   For OpenShift 4.19 and later, specify ``rhel9.6`` instead.
+
+   .. code-block:: console
+
+      $ export PRIVATE_REGISTRY=my/private/registry VGPU_HOST_DRIVER_VERSION=580.82.07 OS_TAG=rhel9.6
 .. note::
 
    The recommended registry to use is the Integrated OpenShift Container Platform registry.


### PR DESCRIPTION
Add the same note that  [commit 3e11d2757eb77f](https://github.com/NVIDIA/cloud-native-docs/commit/3e11d2757eb77fa05eab7ac512c992881989526e) added  in `Steps Overview`  to the OpenShift Virtualization section as well. 


Preview of the change:
<img width="1089" height="540" alt="image" src="https://github.com/user-attachments/assets/94a8601a-682b-4266-ab4a-4e2a65f193e9" />
