### PR TITLE
confidential-containers: Fix for mode change

### DIFF
--- a/gpu-operator/confidential-containers-deploy.rst
+++ b/gpu-operator/confidential-containers-deploy.rst
@@ -314,7 +314,7 @@ Verifying a Mode Change
 To verify that changing the mode was successful, a cluster-wide or node-level change, view the nvidia.com/cc.mode and nvidia.com/cc.mode.state node labels::
 
    $ kubectl get node <node-name> -o json | \
-       jq '.items[0].metadata.labels | with_entries(select(.key | startswith("nvidia.com/cc.mode")))'
+       jq '.metadata.labels | with_entries(select(.key | startswith("nvidia.com/cc.mode")))'
 
 Example output when CC mode is disabled:
 
@@ -370,4 +370,3 @@ Additional Resources
 * NVIDIA Confidential Computing documentation is available at https://docs.nvidia.com/confidential-computing.
 * Trustee Upstream Documentation: https://confidentialcontainers.org/docs/attestation/
 * Trustee NVIDIA Verifier Documentation: https://github.com/confidential-containers/trustee/blob/main/deps/verifier/src/nvidia/README.md
-


### PR DESCRIPTION
Since we query a specific node, we are not expecting a list of items, hence remove part of the jq query.