### PR TITLE
Add ca-certificates to prerequisites for Container Toolkit

### DIFF
--- a/container-toolkit/install-guide.md
+++ b/container-toolkit/install-guide.md
@@ -34,6 +34,7 @@ where `systemd` cgroup drivers are used that cause containers to lose access to 
 1. Install the prerequisites for the instructions below:
    ```console
    $ sudo apt-get update && sudo apt-get install -y --no-install-recommends \
+      ca-certificates \
       curl \
       gnupg2
    ```


### PR DESCRIPTION
When following the NVIDIA Container Toolkit [installation guide](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/install-guide.html), the installation may fail with the following error:

```bash
root@eb7b942aaa4d:/# curl -fsSL https://nvidia.github.io/libnvidia-container/gpgkey
curl: (77) error setting certificate file: /etc/ssl/certs/ca-certificates.crt
```

This issue occurs when `ca-certificates` is not installed, causing HTTPS requests to fail.
Adding `ca-certificates` to the `apt-get install` prerequisites resolves the problem.