### PR TITLE
Fix: Remove Hard Coded CSV in OpenShift Virt Installation Documentation

### DIFF
--- a/openshift/openshift-virtualization.rst
+++ b/openshift/openshift-virtualization.rst
@@ -359,7 +359,9 @@ Create the cluster policy using the CLI:
 
    .. code-block:: console
 
-      $ oc get csv -n nvidia-gpu-operator gpu-operator-certified.v22.9.0 -ojsonpath={.metadata.annotations.alm-examples} | jq .[0] > clusterpolicy.json
+      $ oc get csv -n nvidia-gpu-operator $STARTING_CSV -o jsonpath='{.metadata.annotations.alm-examples}' | jq -r 'map(select(.kind == "ClusterPolicy")) | .[0]' > clusterpolicy.json
+
+   .. note:: ``$STARTING_CSV`` is the value of the ``startingCSV`` field in the ``Subscription`` CR created in the :ref:`install-gpu-ocp` section.
 
 #. Modify the ``clusterpolicy.json`` file as follows:
 


### PR DESCRIPTION
This PR: 
- Includes a fix to remove a hard coded CSV from the installation docs around OpenShift Virtualization. It now points to the much improved section of the broader NVIDIA GPU Operator installation page.

<img width="2906" height="1480" alt="screenshot-2026-03-06-17 34 03" src="https://github.com/user-attachments/assets/7b33fede-2068-4145-8129-28063af54f8c" />
