### PR TITLE
doc: Update Nutanix NKP supported versions in GPU Operator 25.10 platform matrix

### DIFF
--- a/gpu-operator/platform-support.rst
+++ b/gpu-operator/platform-support.rst
@@ -312,7 +312,7 @@ The GPU Operator has been validated in the following scenarios:
          - 1.30---1.35
          -
          -
-         - 2.12, 2.13, 2.14
+         - 
 
        * - Ubuntu 22.04 LTS |fn2|_
          - 1.30---1.35 
@@ -321,7 +321,7 @@ The GPU Operator has been validated in the following scenarios:
          - 1.30---1.35 
          - 1.30---1.35 
          - 1.33---1.35
-         - 2.12, 2.13, 2.14, 2.15
+         - 2.15, 2.16, 2.17
 
        * - Ubuntu 24.04 LTS
          - 1.30---1.35
@@ -330,7 +330,7 @@ The GPU Operator has been validated in the following scenarios:
          - 1.30---1.35
          - 1.30---1.35
          - 1.33---1.35
-         -
+         - 2.17
 
        * - Red Hat Core OS
          -
@@ -350,7 +350,7 @@ The GPU Operator has been validated in the following scenarios:
          - 1.30---1.35
          -
          -
-         -
+         - 2.17
 
        * - | Red Hat
            | Enterprise
@@ -362,7 +362,7 @@ The GPU Operator has been validated in the following scenarios:
          - 1.30---1.35
          -
          -
-         - 2.12, 2.13, 2.14, 2.15
+         - 2.15, 2.16, 2.17
 
     .. _kubernetes-version:
 


### PR DESCRIPTION
Update the Nutanix NKP (Nutanix Kubernetes Platform) column in the GPU Operator platform support table to reflect current support:

- **Ubuntu 20.04 LTS:** drop NKP 2.12, 2.13, 2.14 (end of support)
- **Ubuntu 22.04 LTS:** drop NKP 2.12--2.14, add NKP 2.16 and 2.17
- **Ubuntu 24.04 LTS:** add NKP 2.17 (new platform support)
- **RHEL 9.2, 9.4, 9.6, 9.7:** add NKP 2.17 (new platform support)
- **RHEL 8.8, 8.10:** drop NKP 2.12--2.14, add NKP 2.15, 2.16 and 2.17
This aligns the documentation with GPU Operator v25.10 validated configurations for Nutanix NKP.

<img width="974" height="751" alt="image" src="https://github.com/user-attachments/assets/342a6f49-5a80-4c70-8a60-ec7729ba4ce7" />
