### PR TITLE
Fixed command to get ClusterPolicy

### DIFF
--- a/openshift/install-gpu-ocp.rst
+++ b/openshift/install-gpu-ocp.rst
@@ -225,7 +225,7 @@ Create the cluster policy using the CLI
 
    .. code-block:: console
 
-      $ oc get csv -n nvidia-gpu-operator $STARTING_CSV -o jsonpath='{.metadata.annotations.alm-examples}' | jq -r 'map(select(.kind == "ClusterPolicy")) | .[0]') > clusterpolicy.json 
+      $ oc get csv -n nvidia-gpu-operator $STARTING_CSV -o jsonpath='{.metadata.annotations.alm-examples}' | jq -r 'map(select(.kind == "ClusterPolicy")) | .[0]' > clusterpolicy.json 
 
    .. note:: $STARTING_CSV is the value of the ``startingCSV`` field in the ``Subscription`` CR sample created in the :ref:`install-gpu-ocp` section.
 


### PR DESCRIPTION
Filter part of the command to get the ClusterPolicy was broken (opening 2 brackets but closing 3)