### PR TITLE
Updates for coco 1.1

### DIFF
--- a/confidential-containers/confidential-containers-deploy.rst
+++ b/confidential-containers/confidential-containers-deploy.rst
@@ -142,21 +142,6 @@ Kubernetes Cluster
 * A Kubernetes cluster with cluster administrator privileges.
   Refer to the :ref:`Supported Software Components <coco-supported-software-components>` table for supported Kubernetes versions.
 
-* containerd version 2.2.2 installed.
-  Refer to the `containerd Getting Started guide <https://containerd.io/docs/2.2/getting-started/>`_ for installation instructions.
-
-  To verify the installed version, run the following command:
-
-  .. code-block:: console
-
-      $ containerd --version
-
-  *Example Output:*
-
-  .. code-block:: output
-
-      containerd containerd.io 2.2.2 ...
-
 * Helm installed.
   Use the command below to install Helm or refer to the `Helm documentation <https://helm.sh/docs/intro/install/>`_ for installation instructions.
 
@@ -294,13 +279,13 @@ Install the Kata Containers Helm Chart
 Install Kata Containers using the ``kata-deploy`` Helm chart.
 The ``kata-deploy`` chart installs all required components from the Kata Containers project including the Kata Containers runtime binary, runtime configuration, UVM kernel, and images that NVIDIA uses for Confidential Containers and native Kata containers.
 
-The minimum required version is 3.29.0.
+The minimum required version is ${kata_version}.
 
 #. Set the chart version and registry path:
 
    .. code-block:: console
 
-      $ export VERSION="3.29.0"
+      $ export VERSION="${kata_version}"
       $ export CHART="oci://ghcr.io/kata-containers/kata-deploy-charts/kata-deploy"
 
 
@@ -311,7 +296,6 @@ The minimum required version is 3.29.0.
       $ helm install kata-deploy "${CHART}" \
          --namespace kata-system --create-namespace \
          --set nfd.enabled=false \
-         --wait --timeout 10m \
          --version "${VERSION}"
 
    *Example Output:*
@@ -327,31 +311,43 @@ The minimum required version is 3.29.0.
 
    .. note::
 
-      The ``--wait`` flag in the install command instructs Helm to wait until the release is deployed before returning.
-      It can take a 2-3 minutes to return output.
-
-      There is a `known Helm issue <https://github.com/helm/helm/issues/8660>`_ on single node clusters, that may result in the Helm command finishing before all deployed pods are finished initializing.
-      If you are deploying to a single node cluster, you may need to wait for an additional few minutes after the Helm command completes for the ``kata-deploy`` pod to be in the Running state.
-
-   .. note::
-
       Both ``kata-deploy`` and the GPU Operator deploy Node Feature Discovery (NFD) by default.
       The install command includes ``--set nfd.enabled=false`` to prevent ``kata-deploy`` from deploying NFD.
       The GPU Operator will deploy and manage NFD in the next step.
 
+   .. note::
 
-#. Optional: Verify that the ``kata-deploy`` pod is running:
+      The Helm install command returns as soon as the Kubernetes resources are created.
+      The ``kata-deploy`` DaemonSet then takes several minutes per node to extract artifacts, restart containerd, and label the node before its pods report ready.
+      You can use either of the optional verification steps below to confirm readiness before continuing.
+
+
+#. Optional: Verify that the ``kata-deploy`` DaemonSet has finished rolling out on every node:
 
    .. code-block:: console
 
-      $ kubectl get pods -n kata-system | grep kata-deploy
+      $ kubectl -n kata-system rollout status ds/kata-deploy --timeout=20m
 
    *Example Output:*
 
    .. code-block:: output
 
-      NAME                    READY   STATUS    RESTARTS      AGE
-      kata-deploy-b2lzs       1/1     Running   0             6m37s
+      Waiting for daemon set "kata-deploy" rollout to finish: 0 of 1 updated pods are available...
+      daemon set "kata-deploy" successfully rolled out
+
+
+#. Optional: Verify that the ``kata-deploy`` pods are running:
+
+   .. code-block:: console
+
+      $ kubectl get pods -n kata-system
+
+   *Example Output:*
+
+   .. code-block:: output
+
+      NAME                READY   STATUS    RESTARTS   AGE
+      kata-deploy-b2lzs   1/1     Running   0          6m37s
 
 #. Optional: Verify that the ``kata-qemu-nvidia-gpu``, ``kata-qemu-nvidia-gpu-snp``, and ``kata-qemu-nvidia-gpu-tdx`` runtime classes are available:
 
@@ -415,7 +411,7 @@ Install the NVIDIA GPU Operator and configure it to deploy Confidential Containe
          --set sandboxWorkloads.mode=kata \
          --set nfd.enabled=true \
          --set nfd.nodefeaturerules=true \
-         --version=v26.3.1
+         --version=${gpu_operator_version}
           
 
    *Example Output:*
@@ -701,7 +697,7 @@ The following example installs the GPU Operator with both ``P_GPU_ALIAS`` and ``
       --set kataSandboxDevicePlugin.env[0].value="" \
       --set kataSandboxDevicePlugin.env[1].name=NVSWITCH_ALIAS \
       --set kataSandboxDevicePlugin.env[1].value="" \
-      --version=v26.3.1
+      --version=${gpu_operator_version}
 
 After installing the GPU Operator, you can view the GPU or NVSwitch resource types available on a node by running the following command:
 

--- a/confidential-containers/confidential-containers-deploy.rst
+++ b/confidential-containers/confidential-containers-deploy.rst
@@ -171,7 +171,7 @@ The minimum required version is ${kata_version}.
 
    .. code-block:: output
 
-      Pulled: ghcr.io/kata-containers/kata-deploy-charts/kata-deploy:3.29.0
+      Pulled: ghcr.io/kata-containers/kata-deploy-charts/kata-deploy:${kata_version}
       Digest: sha256:aea41018779716ce2e0bf406d701637d10fb5a0792db51a08dfd3f76701eb933
 
    The ``--wait`` flag in the install command instructs Helm to wait until the release is deployed before returning.
@@ -181,7 +181,7 @@ The minimum required version is ${kata_version}.
 
    .. code-block:: output
 
-      Pulled: ghcr.io/kata-containers/kata-deploy-charts/kata-deploy:3.29.0
+      Pulled: ghcr.io/kata-containers/kata-deploy-charts/kata-deploy:${kata_version}
       Digest: sha256:aea41018779716ce2e0bf406d701637d10fb5a0792db51a08dfd3f76701eb933
       LAST DEPLOYED: Wed Apr  1 17:03:00 2026
       NAMESPACE: kata-system

--- a/confidential-containers/confidential-containers-deploy.rst
+++ b/confidential-containers/confidential-containers-deploy.rst
@@ -153,14 +153,18 @@ The minimum required version is ${kata_version}.
       $ export VERSION="${kata_version}"
       $ export CHART="oci://ghcr.io/kata-containers/kata-deploy-charts/kata-deploy"
 
+#. Create a values file, such as ``kata-nvidia-gpu-values.yaml``, to configure the ``kata-deploy`` chart for NVIDIA Confidential Containers:
 
-#. Install the kata-deploy Helm chart:
+   .. literalinclude:: ./samples/kata-nvidia-gpu-values.yaml
+      :language: yaml
+
+#. Install the kata-deploy Helm chart with the values file:
 
    .. code-block:: console
 
       $ helm install kata-deploy "${CHART}" \
          --namespace kata-system --create-namespace \
-         --set nfd.enabled=false \
+         -f kata-nvidia-gpu-values.yaml \
          --version "${VERSION}"
 
    *Example Output immediately after running the command:*
@@ -199,8 +203,6 @@ The minimum required version is ${kata_version}.
       Both ``kata-deploy`` and the GPU Operator deploy Node Feature Discovery (NFD) by default.
       The install command includes ``--set nfd.enabled=false`` to prevent ``kata-deploy`` from deploying NFD.
       The GPU Operator will deploy and manage NFD in the next step.
-
-   .. note::
 
 #. Verify that the ``kata-deploy`` pod is running:
 

--- a/confidential-containers/confidential-containers-deploy.rst
+++ b/confidential-containers/confidential-containers-deploy.rst
@@ -55,7 +55,7 @@ After completing the installation, you can :doc:`Run a Sample Workload <run-samp
 Label Nodes for Confidential Containers Components
 **************************************************
 
-The GPU Operator reads labels to determine what software components to deploy to a node. 
+The GPU Operator reads labels to determine what software components to deploy to a node.
 To configure a node for Confidential Container workloads, you label the node with the ``nvidia.com/gpu.workload.config=vm-passthrough`` label.
 Then, when the GPU Operator is installed in a subsequent step, it will deploy the software components needed to run Confidential Containers to the node.
 
@@ -144,13 +144,13 @@ Install the Kata Containers Helm Chart
 Install Kata Containers using the ``kata-deploy`` Helm chart.
 The ``kata-deploy`` chart installs all required components from the Kata Containers project including the Kata Containers runtime binary, runtime configuration, UVM kernel, and images that NVIDIA uses for Confidential Containers and native Kata containers.
 
-The minimum required version is 3.29.0.
+The minimum required version is ${kata_version}.
 
 #. Set the chart version and registry path:
 
    .. code-block:: console
 
-      $ export VERSION="3.29.0"
+      $ export VERSION="${kata_version}"
       $ export CHART="oci://ghcr.io/kata-containers/kata-deploy-charts/kata-deploy"
 
 
@@ -161,7 +161,6 @@ The minimum required version is 3.29.0.
       $ helm install kata-deploy "${CHART}" \
          --namespace kata-system --create-namespace \
          --set nfd.enabled=false \
-         --wait --timeout 10m \
          --version "${VERSION}"
 
    *Example Output immediately after running the command:*
@@ -173,7 +172,7 @@ The minimum required version is 3.29.0.
 
    The ``--wait`` flag in the install command instructs Helm to wait until the release is deployed before returning.
    It can take a 2-3 minutes to return more output.
- 
+
    *Example Output when the release is deployed:*
 
    .. code-block:: output
@@ -201,12 +200,13 @@ The minimum required version is 3.29.0.
       The install command includes ``--set nfd.enabled=false`` to prevent ``kata-deploy`` from deploying NFD.
       The GPU Operator will deploy and manage NFD in the next step.
 
+   .. note::
 
 #. Verify that the ``kata-deploy`` pod is running:
 
    .. code-block:: console
 
-      $ kubectl get pods -n kata-system | grep kata-deploy
+      $ kubectl -n kata-system | grep kata-deploy
 
    *Example Output:*
 
@@ -234,10 +234,10 @@ The minimum required version is 3.29.0.
       kata-qemu-nvidia-gpu-tdx   kata-qemu-nvidia-gpu-tdx   40s
 
    Several runtimes are installed by the ``kata-deploy`` chart.
-   The ``kata-qemu-nvidia-gpu`` runtime class is used with Kata 
+   The ``kata-qemu-nvidia-gpu`` runtime class is used with Kata
    Containers, in a non-Confidential Containers scenario.
-   The ``kata-qemu-nvidia-gpu-snp`` for AMD-based systems or 
-   ``kata-qemu-nvidia-gpu-tdx`` for Intel-based systems runtime 
+   The ``kata-qemu-nvidia-gpu-snp`` for AMD-based systems or
+   ``kata-qemu-nvidia-gpu-tdx`` for Intel-based systems runtime
    classes are used to deploy Confidential Containers workloads.
 
    The ``kata-deploy`` chart typically creates these runtime classes within 1-2 minutes after the ``kata-deploy`` pod reaches ``Running``.
@@ -300,7 +300,7 @@ For more details on each of the GPU Operator components, refer to the :ref:`GPU 
          --set sandboxWorkloads.mode=kata \
          --set nfd.enabled=true \
          --set nfd.nodefeaturerules=true \
-         --version=v26.3.1
+         --version=${gpu_operator_version}
 
    *Example Output:*
 
@@ -316,7 +316,7 @@ For more details on each of the GPU Operator components, refer to the :ref:`GPU 
    ``STATUS: deployed`` confirms the Helm release succeeded.
    The ``--wait`` flag instructs Helm to wait until the release is deployed before returning.
    It may take 3-5 minutes for the Helm command to complete.
-   
+
    Use the following steps to confirm the GPU Operator components are deployed and configured correctly.
 
 #. Verify that all GPU Operator pods, especially the Confidential Computing Manager, Kata Device Plugin and VFIO Manager operands, are running:
@@ -436,17 +436,17 @@ The following example installs the GPU Operator with both ``P_GPU_ALIAS`` and ``
 .. code-block:: console
 
    $ helm install --wait --timeout 10m --generate-name \
-        -n gpu-operator --create-namespace \
-        nvidia/gpu-operator \
-        --set sandboxWorkloads.enabled=true \
-        --set sandboxWorkloads.mode=kata \
-        --set nfd.enabled=true \
-        --set nfd.nodefeaturerules=true \
-        --set kataSandboxDevicePlugin.env[0].name=P_GPU_ALIAS \
-        --set kataSandboxDevicePlugin.env[0].value="" \
-        --set kataSandboxDevicePlugin.env[1].name=NVSWITCH_ALIAS \
-        --set kataSandboxDevicePlugin.env[1].value="" \
-        --version=v26.3.1
+      -n gpu-operator --create-namespace \
+      nvidia/gpu-operator \
+      --set sandboxWorkloads.enabled=true \
+      --set sandboxWorkloads.mode=kata \
+      --set nfd.enabled=true \
+      --set nfd.nodefeaturerules=true \
+      --set kataSandboxDevicePlugin.env[0].name=P_GPU_ALIAS \
+      --set kataSandboxDevicePlugin.env[0].value="" \
+      --set kataSandboxDevicePlugin.env[1].name=NVSWITCH_ALIAS \
+      --set kataSandboxDevicePlugin.env[1].value="" \
+      --version=${gpu_operator_version}
 
 After installing the GPU Operator, you can view the GPU or NVSwitch resource types available on a node by running the following command:
 
@@ -474,7 +474,7 @@ Next Steps
 
 .. note::
 
-   You now have a working Confidential Containers runtime. 
+   You now have a working Confidential Containers runtime.
 
    Attestation is what cryptographically verifies the TEE and releases secrets to a
    production workload. For attestation concepts and a local

--- a/confidential-containers/install-quickstart.rst
+++ b/confidential-containers/install-quickstart.rst
@@ -55,7 +55,7 @@ Install the Kata Containers Helm Chart
 
    .. code-block:: console
 
-      $ export VERSION="3.29.0"
+      $ export VERSION="${kata_version}"
       $ export CHART="oci://ghcr.io/kata-containers/kata-deploy-charts/kata-deploy"
 
 #. Install the ``kata-deploy`` Helm chart:
@@ -72,7 +72,7 @@ Install the Kata Containers Helm Chart
 
    .. code-block:: output
 
-      Pulled: ghcr.io/kata-containers/kata-deploy-charts/kata-deploy:3.29.0
+      Pulled: ghcr.io/kata-containers/kata-deploy-charts/kata-deploy:${kata_version}
       Digest: sha256:aea41018779716ce2e0bf406d701637d10fb5a0792db51a08dfd3f76701eb933
       LAST DEPLOYED: Wed Apr  1 17:03:00 2026
       NAMESPACE: kata-system

--- a/confidential-containers/prerequisites.rst
+++ b/confidential-containers/prerequisites.rst
@@ -27,19 +27,18 @@ As a :ref:`Kubernetes Cluster Administrator <coco-persona-kubernetes-cluster-adm
 You perform most steps in this section.
 If you do not have access to host firmware, coordinate with your :ref:`Hardware IT Administrator <coco-persona-hardware-it-administrator>` or :ref:`Host OS Administrator <coco-persona-host-os-administrator>` to confirm or implement hardware prerequisites.
 
-For validated hardware and software versions, refer to :doc:`Supported Platforms <supported-platforms>`.
-Use the checklists below for an at-a-glance summary, then follow each linked section for verification steps.
+Use the following checklists as at-a-glance summary and supplement to the :doc:`Supported Platforms <supported-platforms>` page.
 
-**Hardware prerequisites**
+**Hardware Configuration Requirements**
+
+For validated hardware, refer to :doc:`Supported Platforms <supported-platforms>`.
 
 .. list-table::
    :header-rows: 1
    :widths: 30 70
 
-   * - Prerequisite
+   * - Configuration Requirement
      - Details
-   * - :ref:`Use a supported platform <coco-prereq-supported-platform>`
-     - CPU, GPU, and host OS match :doc:`Supported Platforms <supported-platforms>`
    * - :ref:`Hardware virtualization and ACS enabled <coco-prereq-hw-virtualization>`
      - Hardware virtualization and ACS enabled in host BIOS
    * - :ref:`IOMMU enabled <coco-prereq-iommu>`
@@ -47,26 +46,26 @@ Use the checklists below for an at-a-glance summary, then follow each linked sec
    * - :ref:`No host NVIDIA GPU drivers <coco-prereq-no-host-drivers>`
      - No NVIDIA GPU drivers installed or loaded on worker hosts.
 
-**Cluster prerequisites**
+**Cluster Configuration Requirements**
+
+For validated software components, refer to :doc:`Supported Platforms <supported-platforms>`.
 
 .. list-table::
    :header-rows: 1
    :widths: 30 70
 
-   * - Prerequisite
+   * - Configuration Requirement
      - Details
    * - :ref:`A Kubernetes cluster and cluster administrator access <coco-prereq-cluster-admin>`
-     - Cluster administrator access to a Kubernetes cluster running a supported version (refer to :ref:`Supported Software Components <coco-supported-software-components>`)
-   * - :ref:`containerd 2.2.2 installed <coco-prereq-containerd>`
-     - containerd 2.2.2 installed on each GPU worker node
+     - Cluster administrator access to a Kubernetes cluster running a supported version.
    * - :ref:`Helm installed <coco-prereq-helm>`
      - Helm installed on your cluster administration system
    * - :ref:`Kubelet configured <coco-prereq-kubelet>`
      - Enable ``KubeletPodResourcesGet`` (required before Kubernetes v1.34) and ``RuntimeClassInImageCriApi`` feature gates; set ``runtimeRequestTimeout: 20m`` on GPU worker nodes
 
-*****************
-Hardware and BIOS
-*****************
+********************************************
+Hardware and BIOS Configuration Requirements
+********************************************
 
 .. _coco-prereq-supported-platform:
 
@@ -172,9 +171,9 @@ In this architecture, the NVIDIA GPU Operator handles GPU driver installation an
 
    Refer to `Removing the Driver <https://docs.nvidia.com/datacenter/tesla/driver-installation-guide/removing-the-driver.html>`_ in the NVIDIA Driver Installation Guide.
 
-******************
-Kubernetes Cluster
-******************
+*********************************************
+Kubernetes Cluster Configuration Requirements
+*********************************************
 
 The following sections describe requirements for worker nodes and for the system you use for cluster administration.
 
@@ -185,26 +184,6 @@ Kubernetes Cluster and Cluster Administrator Access
 
 You must have cluster administrator access to a Kubernetes cluster running a supported Kubernetes version.
 Refer to the :ref:`Supported Software Components <coco-supported-software-components>` section in :doc:`Supported Platforms <supported-platforms>` for supported Kubernetes and component versions.
-
-.. _coco-prereq-containerd:
-
-containerd 2.2.2
-================
-
-Verify the installed version on each GPU worker node:
-
-.. code-block:: console
-
-  $ containerd --version
-
-*Example Output:*
-
-.. code-block:: output
-
-  containerd containerd.io 2.2.2 ...
-
-Your actual output may vary, but the reported version must be ``2.2.2``.
-If you are running a different version on any worker node, refer to the `containerd Getting Started guide <https://containerd.io/docs/2.2/getting-started/>`_ for installation instructions.
 
 .. _coco-prereq-helm:
 
@@ -256,7 +235,7 @@ Apply these settings as follows:
 #. Open the kubelet configuration file:
 
    .. code-block:: console
-      
+
       $ sudo nano /var/lib/kubelet/config.yaml
 
    This is typically located at ``/var/lib/kubelet/config.yaml``, but your configuration file may be in a different location.

--- a/confidential-containers/release-notes.rst
+++ b/confidential-containers/release-notes.rst
@@ -26,6 +26,28 @@ This document describes the new features and known issues for the NVIDIA Confide
 
 ----
 
+.. _coco-v1.1.0:
+
+1.1.0
+=====
+
+This release expands hardware coverage and updates the validated software stack.
+
+New Features
+------------
+
+* Added support for the NVIDIA HGX B300 platform with both single-GPU and multi-GPU passthrough.
+
+* Added support for Ubuntu 26.04 as a host operating system.
+
+* Added support for the following software components:
+
+  * Kata Containers 3.31.0 
+  * containerd 2.3.x
+  * NVIDIA GPU Operator v26.3.1
+
+----
+
 .. _coco-v1.0.0:
 
 1.0.0

--- a/confidential-containers/release-notes.rst
+++ b/confidential-containers/release-notes.rst
@@ -44,7 +44,6 @@ New Features
 
   * Kata Containers 3.31.0 
   * containerd 2.3.x
-  * NVIDIA GPU Operator v26.3.1
 
 ----
 

--- a/confidential-containers/release-notes.rst
+++ b/confidential-containers/release-notes.rst
@@ -45,6 +45,19 @@ New Features
   * Kata Containers 3.31.0 
   * containerd 2.3.x
 
+
+Docs Changelog
+--------------
+
+The :ref:`coco-install-kata-chart` procedure was updated for this release.
+Changes include:
+
+* Installs ``kata-deploy`` with a values file instead of inline ``--set`` flags.
+
+* Includes a new sample values file, :file:`samples/kata-nvidia-gpu-values.yaml`, that configures the ``kata-deploy`` Helm chart for the NVIDIA Confidential Containers reference architecture (NVIDIA GPU shims only, NFD disabled, ``nydus`` snapshotter, and per-shim runtime class node selectors).
+
+* Adds a readiness verification step using ``kubectl rollout status ds/kata-deploy``. This step relies on the readiness reporting added in Kata Containers 3.31.0 and lets you confirm that ``kata-deploy`` has finished extracting artifacts and restarting containerd on every node before continuing.
+
 ----
 
 .. _coco-v1.0.0:

--- a/confidential-containers/release-notes.rst
+++ b/confidential-containers/release-notes.rst
@@ -42,7 +42,7 @@ New Features
 
 * Added support for the following software components:
 
-  * Kata Containers 3.31.0 
+  * Kata Containers ${kata_version}
   * containerd 2.3.x
 
 
@@ -56,7 +56,7 @@ Changes include:
 
 * Includes a new sample values file, :file:`samples/kata-nvidia-gpu-values.yaml`, that configures the ``kata-deploy`` Helm chart for the NVIDIA Confidential Containers reference architecture (NVIDIA GPU shims only, NFD disabled, ``nydus`` snapshotter, and per-shim runtime class node selectors).
 
-* Adds a readiness verification step using ``kubectl rollout status ds/kata-deploy``. This step relies on the readiness reporting added in Kata Containers 3.31.0 and lets you confirm that ``kata-deploy`` has finished extracting artifacts and restarting containerd on every node before continuing.
+* Adds a readiness verification step using ``kubectl rollout status ds/kata-deploy``. This step relies on the readiness reporting in Kata Containers and lets you confirm that ``kata-deploy`` has finished extracting artifacts and restarting containerd on every node before continuing.
 
 ----
 
@@ -82,7 +82,7 @@ Key Features
   - NVIDIA H200 Protected PCIe (multi-GPU passthrough)
   - NVIDIA B200 (single-GPU and multi-GPU passthrough)
   - NVIDIA RTX Pro 6000 BSE (single-GPU passthrough)
-  - AMD Genoa / Milan CPUs with Ubuntu 25.10 (kernel 6.17+) for SEV-SNP 
+  - AMD Genoa / Milan CPUs with Ubuntu 25.10 (kernel 6.17+) for SEV-SNP
   - Intel Emerald Rapids / Granite Rapids CPUs with Ubuntu 25.10 (kernel 6.17+) for TDX
 
 * This release supports the following software components:

--- a/confidential-containers/release-notes.rst
+++ b/confidential-containers/release-notes.rst
@@ -45,6 +45,9 @@ New Features
   * Kata Containers ${kata_version}
   * containerd 2.3.x
 
+* This release has General Availability support for most platforms running Red Hat OpenShift Sandboxed Containers 1.13.
+  Refer to `Confidential containers: feature availability by OpenShift Container Platform version <https://docs.redhat.com/en/documentation/openshift_sandboxed_containers/1.13/html/deploying_confidential_containers_on_bare-metal_servers/cc-discover_metal-cc#idm140411685844384>`__.
+
 
 Docs Changelog
 --------------

--- a/confidential-containers/release-notes.rst
+++ b/confidential-containers/release-notes.rst
@@ -43,6 +43,7 @@ New Features
 * Added support for the following software components:
 
   * Kata Containers ${kata_version}
+  * Kata Lifecycle Manager 0.1.8
   * containerd 2.3.x
 
 * This release has General Availability support for most platforms running Red Hat OpenShift Sandboxed Containers 1.13.
@@ -92,7 +93,7 @@ Key Features
 
   - NVIDIA GPU Operator v26.3.1
   - Kata Containers 3.29 (installed with the ``kata-deploy`` Helm chart)
-  - Kata Lifecycle Manager 0.1.8
+  - Kata Lifecycle Manager 0.1.4
   - Key Broker Service (KBS) protocol 0.4.0
   - QEMU 10.1 + Patches
   - OVMF edk2-stable202511

--- a/confidential-containers/release-notes.rst
+++ b/confidential-containers/release-notes.rst
@@ -89,7 +89,7 @@ Key Features
 
   - NVIDIA GPU Operator v26.3.1
   - Kata Containers 3.29 (installed with the ``kata-deploy`` Helm chart)
-  - Kata Lifecycle Manager 0.1.4
+  - Kata Lifecycle Manager 0.1.8
   - Key Broker Service (KBS) protocol 0.4.0
   - QEMU 10.1 + Patches
   - OVMF edk2-stable202511

--- a/confidential-containers/release-notes.rst
+++ b/confidential-containers/release-notes.rst
@@ -26,6 +26,28 @@ This document describes the new features and known issues for the NVIDIA Confide
 
 ----
 
+.. _coco-v1.1.0:
+
+1.1.0
+=====
+
+This release expands hardware coverage and updates the validated software stack.
+
+New Features
+------------
+
+* Added support for the NVIDIA HGX B300 platform with both single-GPU and multi-GPU passthrough.
+
+* Added support for Ubuntu 26.04 as a host operating system.
+
+* Added support for the following software components:
+
+  * Kata Containers 3.31.0 
+  * containerd 2.3.x
+  * NVIDIA GPU Operator v26.3.1
+
+----
+
 .. _coco-v1.0.0:
 
 *****

--- a/confidential-containers/samples/kata-nvidia-gpu-values.yaml
+++ b/confidential-containers/samples/kata-nvidia-gpu-values.yaml
@@ -1,0 +1,125 @@
+# Example values file to enable NVIDIA GPU shims for the NVIDIA
+# Confidential Containers Reference Architecture. 
+
+# Disable verbose debug logging in kata-deploy and the Kata runtime. Change this to true if you want to troubleshoot issues.
+debug: false
+
+# Disable Node Feature Discovery (NFD) deployment by kata-deploy.
+# Both kata-deploy and the GPU Operator deploy NFD by default. This
+# reference architecture relies on the NFD instance that the GPU Operator
+# deploys and manages, so the kata-deploy NFD is turned off to avoid a
+# duplicate, conflicting deployment.
+nfd:
+  enabled: false
+
+# Install the nydus snapshotter on each node alongside containerd.
+# The confidential -snp and -tdx shims below use nydus to pull container
+# images directly into the confidential VM (guest pull), which keeps image
+# contents inside the trusted execution environment (TEE).
+snapshotter:
+  setup: ["nydus"]
+
+# Disable every shim the kata-deploy chart enables by default, then opt in
+# only to the NVIDIA GPU shims.
+# The default chart installs a broad set of hypervisor and TEE shims
+# (clh, dragonball, fc, qemu, qemu-sev, qemu-snp, qemu-tdx, stratovirt,
+# and the -runtime-rs variants) that are not part of this reference
+# architecture.
+shims:
+  disableAll: true
+
+  # Non-confidential NVIDIA GPU passthrough shim used when Confidential
+  # Computing mode is off on the node. The runtime class is restricted to
+  # nodes where the GPU Operator's Confidential Computing Manager has
+  # reported nvidia.com/cc.ready.state=false, so it will not schedule on
+  # CC-ready nodes. The empty containerd snapshotter falls back to the
+  # default (overlayfs); guest pull is not used for this non-confidential
+  # path.
+  qemu-nvidia-gpu:
+    enabled: true
+    supportedArches:
+      - amd64
+    allowedHypervisorAnnotations: []
+    containerd:
+      snapshotter: ""
+    runtimeClass:
+      # This label is automatically added by the GPU Operator. 
+      nodeSelector:
+        nvidia.com/cc.ready.state: "false"
+
+  # Note: the upstream kata-deploy chart also distributes -runtime-rs
+  # variants of the NVIDIA GPU shims (an alternative Rust-based runtime).
+  # They are not yet supported by this reference architecture and are
+  # left disabled by the disableAll setting above.
+
+  # Confidential NVIDIA GPU passthrough shim for AMD SEV-SNP nodes.
+  # The runtime class is pinned to nodes where the GPU Operator has set
+  # nvidia.com/cc.ready.state=true (CC mode applied) AND where Node
+  # Feature Discovery has set amd.feature.node.kubernetes.io/snp=true
+  # (host CPU advertises SEV-SNP). The nydus containerd snapshotter and
+  # CRI-O guestPull pull container images directly into the confidential
+  # VM. Set agent.httpsProxy / agent.noProxy if the guest needs to reach
+  # the registry through a proxy.
+  qemu-nvidia-gpu-snp:
+    enabled: true
+    supportedArches:
+      - amd64
+    allowedHypervisorAnnotations: []
+    containerd:
+      snapshotter: "nydus"
+      forceGuestPull: false
+    crio:
+      guestPull: true
+    agent:
+      httpsProxy: ""
+      noProxy: ""
+    runtimeClass:
+      # These labels are automatically added by the GPU Operator and NFD
+      # respectively.
+      nodeSelector:
+        nvidia.com/cc.ready.state: "true"
+        amd.feature.node.kubernetes.io/snp: "true"
+
+  # Confidential NVIDIA GPU passthrough shim for Intel TDX nodes.
+  # The runtime class is pinned to nodes where the GPU Operator has set
+  # nvidia.com/cc.ready.state=true (CC mode applied) AND where Node
+  # Feature Discovery has set intel.feature.node.kubernetes.io/tdx=true
+  # (host CPU advertises TDX). Snapshotter, guest pull, and proxy
+  # behavior match the SNP shim above.
+  qemu-nvidia-gpu-tdx:
+    enabled: true
+    supportedArches:
+      - amd64
+    allowedHypervisorAnnotations: []
+    containerd:
+      snapshotter: "nydus"
+      forceGuestPull: false
+    crio:
+      guestPull: true
+    agent:
+      httpsProxy: ""
+      noProxy: ""
+    runtimeClass:
+      # These labels are automatically added by the GPU Operator and NFD
+      # respectively.
+      nodeSelector:
+        nvidia.com/cc.ready.state: "true"
+        intel.feature.node.kubernetes.io/tdx: "true"
+
+# Default shim per architecture used by kata-deploy when a pod does not
+# request a specific runtime class. Set to the non-confidential NVIDIA
+# GPU shim so pods only run inside a confidential VM when they
+# explicitly request the kata-qemu-nvidia-gpu-snp or
+# kata-qemu-nvidia-gpu-tdx runtime class.
+defaultShim:
+  amd64: qemu-nvidia-gpu # Can be changed to qemu-nvidia-gpu-snp or qemu-nvidia-gpu-tdx if preferred
+
+# Create one Kubernetes RuntimeClass per enabled shim above
+# (kata-qemu-nvidia-gpu, kata-qemu-nvidia-gpu-snp, kata-qemu-nvidia-gpu-tdx).
+# createDefault: false suppresses the generic "kata" RuntimeClass since
+# you should always reference a specific NVIDIA shim
+# by name in pod specs.
+runtimeClasses:
+  enabled: true
+  createDefault: false
+  defaultName: "kata"

--- a/confidential-containers/samples/kata-nvidia-gpu-values.yaml
+++ b/confidential-containers/samples/kata-nvidia-gpu-values.yaml
@@ -1,7 +1,7 @@
 # Example values file to enable NVIDIA GPU shims for the NVIDIA
 # Confidential Containers Reference Architecture. 
 
-# Disable verbose debug logging in kata-deploy and the Kata runtime. Change this to true if you want to troubleshoot issues.
+# Set to true for verbose kata-deploy and Kata runtime logging.
 debug: false
 
 # Disable Node Feature Discovery (NFD) deployment by kata-deploy.
@@ -19,12 +19,8 @@ nfd:
 snapshotter:
   setup: ["nydus"]
 
-# Disable every shim the kata-deploy chart enables by default, then opt in
-# only to the NVIDIA GPU shims.
-# The default chart installs a broad set of hypervisor and TEE shims
-# (clh, dragonball, fc, qemu, qemu-sev, qemu-snp, qemu-tdx, stratovirt,
-# and the -runtime-rs variants) that are not part of this reference
-# architecture.
+# Disable the chart's default hypervisor/TEE shims and opt in only to
+# the NVIDIA GPU shims supported by this reference architecture.
 shims:
   disableAll: true
 
@@ -47,19 +43,10 @@ shims:
       nodeSelector:
         nvidia.com/cc.ready.state: "false"
 
-  # Note: the upstream kata-deploy chart also distributes -runtime-rs
-  # variants of the NVIDIA GPU shims (an alternative Rust-based runtime).
-  # They are not yet supported by this reference architecture and are
-  # left disabled by the disableAll setting above.
-
-  # Confidential NVIDIA GPU passthrough shim for AMD SEV-SNP nodes.
-  # The runtime class is pinned to nodes where the GPU Operator has set
-  # nvidia.com/cc.ready.state=true (CC mode applied) AND where Node
-  # Feature Discovery has set amd.feature.node.kubernetes.io/snp=true
-  # (host CPU advertises SEV-SNP). The nydus containerd snapshotter and
-  # CRI-O guestPull pull container images directly into the confidential
-  # VM. Set agent.httpsProxy / agent.noProxy if the guest needs to reach
-  # the registry through a proxy.
+  # Confidential NVIDIA GPU passthrough for AMD SEV-SNP nodes.
+  # Scheduled where the GPU Operator reports CC mode is on AND NFD
+  # reports SEV-SNP support. Set agent.httpsProxy / agent.noProxy if
+  # the guest needs a proxy to reach the registry.
   qemu-nvidia-gpu-snp:
     enabled: true
     supportedArches:
@@ -80,12 +67,9 @@ shims:
         nvidia.com/cc.ready.state: "true"
         amd.feature.node.kubernetes.io/snp: "true"
 
-  # Confidential NVIDIA GPU passthrough shim for Intel TDX nodes.
-  # The runtime class is pinned to nodes where the GPU Operator has set
-  # nvidia.com/cc.ready.state=true (CC mode applied) AND where Node
-  # Feature Discovery has set intel.feature.node.kubernetes.io/tdx=true
-  # (host CPU advertises TDX). Snapshotter, guest pull, and proxy
-  # behavior match the SNP shim above.
+  # Confidential NVIDIA GPU passthrough for Intel TDX nodes.
+  # Same selectors and snapshotter behavior as the SNP shim above,
+  # but pinned to TDX-capable hosts.
   qemu-nvidia-gpu-tdx:
     enabled: true
     supportedArches:
@@ -106,11 +90,9 @@ shims:
         nvidia.com/cc.ready.state: "true"
         intel.feature.node.kubernetes.io/tdx: "true"
 
-# Default shim per architecture used by kata-deploy when a pod does not
-# request a specific runtime class. Set to the non-confidential NVIDIA
-# GPU shim so pods only run inside a confidential VM when they
-# explicitly request the kata-qemu-nvidia-gpu-snp or
-# kata-qemu-nvidia-gpu-tdx runtime class.
+# Default shim when a pod does not request a runtime class. Set to the
+# non-confidential shim so pods only run in a confidential VM when
+# they explicitly request the -snp or -tdx runtime class.
 defaultShim:
   amd64: qemu-nvidia-gpu # Can be changed to qemu-nvidia-gpu-snp or qemu-nvidia-gpu-tdx if preferred
 

--- a/confidential-containers/samples/kata-nvidia-gpu-values.yaml
+++ b/confidential-containers/samples/kata-nvidia-gpu-values.yaml
@@ -1,8 +1,10 @@
 # Example values file to enable NVIDIA GPU shims for the NVIDIA
-# Confidential Containers Reference Architecture. 
+# Confidential Containers Reference Architecture.
 
 # Set to true for verbose kata-deploy and Kata runtime logging.
 debug: false
+
+deploymentMode: daemonset
 
 # Disable Node Feature Discovery (NFD) deployment by kata-deploy.
 # Both kata-deploy and the GPU Operator deploy NFD by default. This
@@ -39,7 +41,7 @@ shims:
     containerd:
       snapshotter: ""
     runtimeClass:
-      # This label is automatically added by the GPU Operator. 
+      # This label is automatically added by the GPU Operator.
       nodeSelector:
         nvidia.com/cc.ready.state: "false"
 

--- a/confidential-containers/supported-platforms.rst
+++ b/confidential-containers/supported-platforms.rst
@@ -52,6 +52,9 @@ NVIDIA GPUs
    * - NVIDIA B200
      - Single-GPU, Multi-GPU
 
+   * - NVIDIA HGX B300
+     - Single-GPU, Multi-GPU
+
    * - NVIDIA RTX Pro 6000 BSE
      - Single-GPU
 
@@ -75,10 +78,10 @@ CPU Platforms
      - Operating System
      - Kernel Version
    * - AMD Genoa / Milan
-     - Ubuntu 25.10
+     - Ubuntu 25.10 or 26.04
      - 6.17+
    * - Intel Emerald Rapids (ER) /  Granite Rapids (GR)
-     - Ubuntu 25.10
+     - Ubuntu 25.10 or 26.04
      - 6.17+
 
 For additional information on node configuration, refer to the `Confidential Computing Deployment Guide <https://docs.nvidia.com/cc-deployment-guide-tdx-snp.pdf>`_ for information about supported NVIDIA GPUs, such as the NVIDIA Hopper H100.
@@ -88,7 +91,7 @@ The following topics in the deployment guide apply to a cloud-native environment
 * Hardware selection and initial hardware configuration, such as BIOS settings.
 * Host operating system selection, initial configuration, and validation.
 
-When following the cloud-native sections in the deployment guide linked above, use Ubuntu 25.10 as the host OS with its default kernel version and configuration.
+When following the cloud-native sections in the deployment guide linked above, use Ubuntu 25.10 or 26.04 as the host OS with its default kernel version and configuration.
 
 For additional resources on machine setup:
 
@@ -114,15 +117,15 @@ Supported Software Components
    * - `QEMU <https://www.qemu.org/>`__
      - 10.1 \+ Patches
    * - `Containerd <https://github.com/containerd/containerd>`__
-     - 2.2.2
+     - 2.2.x or 2.3.x
    * - `Kubernetes <https://kubernetes.io/>`__
      - 1.32 \+
    * - `NVIDIA GPU Operator <https://docs.nvidia.com/datacenter/cloud-native/gpu-operator/latest/index.html>`__ and its components.
-       
+
        Refer to the :ref:`GPU Operator Component Matrix <gpuop:operator-component-matrix>` for the list of components and versions included in each release.
-     - v26.3.1 and higher
+     - ${gpu_operator_version} and higher
    * - `Kata Containers <https://katacontainers.io/>`__
-     - 3.29 (installed with ``kata-deploy`` Helm chart)
+     - ${kata_version} (installed with ``kata-deploy`` Helm chart)
    * - `Key Broker Service (KBS) protocol <https://confidentialcontainers.org/docs/attestation/>`__
      - 0.4.0
    * - `Kata Lifecycle Manager <https://github.com/kata-containers/lifecycle-manager>`__

--- a/confidential-containers/supported-platforms.rst
+++ b/confidential-containers/supported-platforms.rst
@@ -59,6 +59,9 @@ NVIDIA GPUs
    * - NVIDIA B200
      - Single-GPU, Multi-GPU
 
+   * - NVIDIA HGX B300
+     - Single-GPU, Multi-GPU
+
    * - NVIDIA RTX Pro 6000 BSE
      - Single-GPU
 
@@ -84,11 +87,11 @@ CPU Platforms
      - Kernel Version
    * - AMD Genoa / Milan
      - AMD SEV-SNP
-     - Ubuntu 25.10
+     - Ubuntu 25.10 or 26.04
      - 6.17+
    * - Intel Emerald Rapids (ER) /  Granite Rapids (GR)
      - Intel TDX
-     - Ubuntu 25.10
+     - Ubuntu 25.10 or 26.04
      - 6.17+
 
 For additional information on node configuration, refer to the `Confidential Computing Deployment Guide <https://docs.nvidia.com/cc-deployment-guide-tdx-snp.pdf>`_ for information about supported NVIDIA GPUs, such as the NVIDIA Hopper H100.
@@ -98,7 +101,7 @@ The following topics in the deployment guide apply to a cloud-native environment
 * Hardware selection and initial hardware configuration, such as BIOS settings.
 * Host operating system selection, initial configuration, and validation.
 
-When following the cloud-native sections in the deployment guide linked above, use Ubuntu 25.10 as the host OS with its default kernel version and configuration.
+When following the cloud-native sections in the deployment guide linked above, use Ubuntu 25.10 or 26.04 as the host OS with its default kernel version and configuration.
 
 For additional resources on machine setup:
 
@@ -126,24 +129,18 @@ Supported Software Components
    * - `QEMU <https://www.qemu.org/>`__
      - 10.1 \+ Patches
    * - `Containerd <https://github.com/containerd/containerd>`__
-     - 2.2.2
+     - 2.2.x or 2.3.x
    * - `Kubernetes <https://kubernetes.io/>`__
      - 1.32 \+
    * - `NVIDIA GPU Operator <https://docs.nvidia.com/datacenter/cloud-native/gpu-operator/latest/index.html>`__ and its components.
-       
+
        Refer to the :ref:`GPU Operator Component Matrix <gpuop:operator-component-matrix>` for the list of components and versions included in each release.
-     - v26.3.1 and higher
+     - ${gpu_operator_version} and higher
    * - `Kata Containers <https://katacontainers.io/>`__
-     - 3.29 (installed with ``kata-deploy`` Helm chart)
+     - ${kata_version} (installed with ``kata-deploy`` Helm chart)
    * - `Key Broker Service (KBS) protocol <https://confidentialcontainers.org/docs/attestation/>`__
      - 0.4.0
    * - `Kata Lifecycle Manager <https://github.com/kata-containers/lifecycle-manager>`__
      - 0.1.4
 
 Users may leverage `Red Hat OpenShift Sandboxed Containers <https://docs.redhat.com/en/documentation/openshift_sandboxed_containers/1.12>`__ to deploy Confidential Containers, however, Confidential GPU features are currently classified as Technology Preview by the downstream provider.
-
-
-
-
-
-

--- a/confidential-containers/supported-platforms.rst
+++ b/confidential-containers/supported-platforms.rst
@@ -129,7 +129,7 @@ Supported Software Components
    * - `QEMU <https://www.qemu.org/>`__
      - 10.1 \+ Patches
    * - `Containerd <https://github.com/containerd/containerd>`__
-     - 2.2.2 or 2.3.x 
+     - 2.3.x
    * - `Kubernetes <https://kubernetes.io/>`__
      - 1.32 \+
    * - `NVIDIA GPU Operator <https://docs.nvidia.com/datacenter/cloud-native/gpu-operator/latest/index.html>`__ and its components.

--- a/confidential-containers/supported-platforms.rst
+++ b/confidential-containers/supported-platforms.rst
@@ -143,4 +143,4 @@ Supported Software Components
    * - `Kata Lifecycle Manager <https://github.com/kata-containers/lifecycle-manager>`__
      - 0.1.8
 
-Users may leverage `Red Hat OpenShift Sandboxed Containers <https://docs.redhat.com/en/documentation/openshift_sandboxed_containers/1.13>`__ to deploy Confidential Containers, however, Confidential GPU features are currently classified as Technology Preview by the downstream provider.
+Users may leverage `Red Hat OpenShift Sandboxed Containers <https://docs.redhat.com/en/documentation/openshift_sandboxed_containers/1.13>`__ to deploy Confidential Containers.

--- a/confidential-containers/supported-platforms.rst
+++ b/confidential-containers/supported-platforms.rst
@@ -129,7 +129,7 @@ Supported Software Components
    * - `QEMU <https://www.qemu.org/>`__
      - 10.1 \+ Patches
    * - `Containerd <https://github.com/containerd/containerd>`__
-     - 2.2.x or 2.3.x
+     - 2.2.2 or 2.3.x 
    * - `Kubernetes <https://kubernetes.io/>`__
      - 1.32 \+
    * - `NVIDIA GPU Operator <https://docs.nvidia.com/datacenter/cloud-native/gpu-operator/latest/index.html>`__ and its components.

--- a/confidential-containers/supported-platforms.rst
+++ b/confidential-containers/supported-platforms.rst
@@ -141,6 +141,6 @@ Supported Software Components
    * - `Key Broker Service (KBS) protocol <https://confidentialcontainers.org/docs/attestation/>`__
      - 0.4.0
    * - `Kata Lifecycle Manager <https://github.com/kata-containers/lifecycle-manager>`__
-     - 0.1.4
+     - 0.1.8
 
-Users may leverage `Red Hat OpenShift Sandboxed Containers <https://docs.redhat.com/en/documentation/openshift_sandboxed_containers/1.12>`__ to deploy Confidential Containers, however, Confidential GPU features are currently classified as Technology Preview by the downstream provider.
+Users may leverage `Red Hat OpenShift Sandboxed Containers <https://docs.redhat.com/en/documentation/openshift_sandboxed_containers/1.13>`__ to deploy Confidential Containers, however, Confidential GPU features are currently classified as Technology Preview by the downstream provider.

--- a/gpu-operator/deploy-kata-containers.rst
+++ b/gpu-operator/deploy-kata-containers.rst
@@ -280,13 +280,13 @@ Install the Kata Containers Helm Chart
 Install Kata Containers using the ``kata-deploy`` Helm chart.
 The ``kata-deploy`` chart installs all required components from the Kata Containers project including the Kata Containers runtime binary, runtime configuration, UVM kernel, and images that NVIDIA uses for Kata Containers.
 
-The minimum required version is 3.29.0.
+The minimum required version is ${kata_version}.
 
 #. Set the chart version and registry path:
 
    .. code-block:: console
 
-      $ export VERSION="3.29.0"
+      $ export VERSION="${kata_version}"
       $ export CHART="oci://ghcr.io/kata-containers/kata-deploy-charts/kata-deploy"
 
 
@@ -297,7 +297,6 @@ The minimum required version is 3.29.0.
       $ helm install kata-deploy "${CHART}" \
          --namespace kata-system --create-namespace \
          --set nfd.enabled=false \
-         --wait --timeout 10m \
          --version "${VERSION}"
 
    *Example Output:*
@@ -313,31 +312,43 @@ The minimum required version is 3.29.0.
 
    .. note::
 
-      The ``--wait`` flag in the install command instructs Helm to wait until the release is deployed before returning.
-      It can take a few minutes to return output.
-
-      There is a `known Helm issue <https://github.com/helm/helm/issues/8660>`_ on single node clusters, that may result in the Helm command finishing before all deployed pods are finished initializing.
-      If you are deploying to a single node cluster, you may need to wait for an additional few minutes after the Helm command completes for the ``kata-deploy`` pod to be in the Running state.
-
-   .. note::
-
       Both ``kata-deploy`` and the GPU Operator deploy Node Feature Discovery (NFD) by default.
       The install command includes ``--set nfd.enabled=false`` to prevent ``kata-deploy`` from deploying NFD.
       The GPU Operator will deploy and manage NFD in the next step.
 
+   .. note::
 
-#. Optional: Verify that the ``kata-deploy`` pod is running:
+      The Helm install command returns as soon as the Kubernetes resources are created.
+      The ``kata-deploy`` DaemonSet then takes several minutes per node to extract artifacts, restart containerd, and label the node before its pods report ready.
+      You can use either of the optional verification steps below to confirm readiness before continuing.
+
+
+#. Optional: Verify that the ``kata-deploy`` DaemonSet has finished rolling out on every node:
 
    .. code-block:: console
 
-      $ kubectl get pods -n kata-system | grep kata-deploy
+      $ kubectl -n kata-system rollout status ds/kata-deploy --timeout=20m
 
    *Example Output:*
 
    .. code-block:: output
 
-      NAME                    READY   STATUS    RESTARTS      AGE
-      kata-deploy-b2lzs       1/1     Running   0             6m37s
+      Waiting for daemon set "kata-deploy" rollout to finish: 0 of 1 updated pods are available...
+      daemon set "kata-deploy" successfully rolled out
+
+
+#. Optional: Verify that the ``kata-deploy`` pods are running:
+
+   .. code-block:: console
+
+      $ kubectl get pods -n kata-system
+
+   *Example Output:*
+
+   .. code-block:: output
+
+      NAME                READY   STATUS    RESTARTS   AGE
+      kata-deploy-b2lzs   1/1     Running   0          6m37s
 
 #. Optional: Verify that the ``kata-qemu-nvidia-gpu`` runtime class is available:
 

--- a/gpu-operator/deploy-kata-containers.rst
+++ b/gpu-operator/deploy-kata-containers.rst
@@ -305,13 +305,13 @@ Install the Kata Containers Helm Chart
 Install Kata Containers using the ``kata-deploy`` Helm chart.
 The ``kata-deploy`` chart installs all required components from the Kata Containers project including the Kata Containers runtime binary, runtime configuration, UVM kernel, and images that NVIDIA uses for Kata Containers.
 
-The minimum required version is 3.29.0.
+The minimum required version is ${kata_version}.
 
 #. Set the chart version and registry path:
 
    .. code-block:: console
 
-      $ export VERSION="3.29.0"
+      $ export VERSION="${kata_version}"
       $ export CHART="oci://ghcr.io/kata-containers/kata-deploy-charts/kata-deploy"
 
 
@@ -322,7 +322,6 @@ The minimum required version is 3.29.0.
       $ helm install kata-deploy "${CHART}" \
          --namespace kata-system --create-namespace \
          --set nfd.enabled=false \
-         --wait --timeout 10m \
          --version "${VERSION}"
 
    *Example Output:*
@@ -338,31 +337,43 @@ The minimum required version is 3.29.0.
 
    .. note::
 
-      The ``--wait`` flag in the install command instructs Helm to wait until the release is deployed before returning.
-      It can take a few minutes to return output.
-
-      There is a `known Helm issue <https://github.com/helm/helm/issues/8660>`_ on single node clusters, that may result in the Helm command finishing before all deployed pods are finished initializing.
-      If you are deploying to a single node cluster, you may need to wait for an additional few minutes after the Helm command completes for the ``kata-deploy`` pod to be in the Running state.
-
-   .. note::
-
       Both ``kata-deploy`` and the GPU Operator deploy Node Feature Discovery (NFD) by default.
       The install command includes ``--set nfd.enabled=false`` to prevent ``kata-deploy`` from deploying NFD.
       The GPU Operator will deploy and manage NFD in the next step.
 
+   .. note::
 
-#. Optional: Verify that the ``kata-deploy`` pod is running:
+      The Helm install command returns as soon as the Kubernetes resources are created.
+      The ``kata-deploy`` DaemonSet then takes several minutes per node to extract artifacts, restart containerd, and label the node before its pods report ready.
+      You can use either of the optional verification steps below to confirm readiness before continuing.
+
+
+#. Optional: Verify that the ``kata-deploy`` DaemonSet has finished rolling out on every node:
 
    .. code-block:: console
 
-      $ kubectl get pods -n kata-system | grep kata-deploy
+      $ kubectl -n kata-system rollout status ds/kata-deploy --timeout=20m
 
    *Example Output:*
 
    .. code-block:: output
 
-      NAME                    READY   STATUS    RESTARTS      AGE
-      kata-deploy-b2lzs       1/1     Running   0             6m37s
+      Waiting for daemon set "kata-deploy" rollout to finish: 0 of 1 updated pods are available...
+      daemon set "kata-deploy" successfully rolled out
+
+
+#. Optional: Verify that the ``kata-deploy`` pods are running:
+
+   .. code-block:: console
+
+      $ kubectl get pods -n kata-system
+
+   *Example Output:*
+
+   .. code-block:: output
+
+      NAME                READY   STATUS    RESTARTS   AGE
+      kata-deploy-b2lzs   1/1     Running   0          6m37s
 
 #. Optional: Verify that the ``kata-qemu-nvidia-gpu`` runtime class is available:
 

--- a/gpu-operator/deploy-kata-containers.rst
+++ b/gpu-operator/deploy-kata-containers.rst
@@ -347,7 +347,6 @@ The minimum required version is ${kata_version}.
 
    .. note::
 
-      The Helm install command returns as soon as the Kubernetes resources are created.
       The ``kata-deploy`` DaemonSet then takes several minutes per node to extract artifacts, restart containerd, and label the node before its pods report ready.
       You can use either of the optional verification steps below to confirm readiness before continuing.
 

--- a/gpu-operator/deploy-kata-containers.rst
+++ b/gpu-operator/deploy-kata-containers.rst
@@ -32,7 +32,7 @@ Deploy with Kata Containers
 About the Operator with Kata Containers
 ***************************************
 
-`Kata Containers <https://katacontainers.io/>`_ is an open source project that creates lightweight Virtual Machines (VMs) that feel and perform like traditional containers such as a Docker container. 
+`Kata Containers <https://katacontainers.io/>`_ is an open source project that creates lightweight Virtual Machines (VMs) that feel and perform like traditional containers such as a Docker container.
 A traditional container packages software for user-space isolation from the host,
 but the container runs on the host and shares the operating system kernel with the host.
 Sharing the operating system kernel is a potential vulnerability.
@@ -129,9 +129,9 @@ To enable Kata Containers for GPUs on your cluster, you do the following:
 
 #. Make sure your cluster meets the prerequisites.
 #. Label the nodes you want to use for Kata Containers.
-#. Install the upstream ``kata-deploy`` Helm chart, which deploys all Kata runtime classes, including NVIDIA-specific runtime classes. 
+#. Install the upstream ``kata-deploy`` Helm chart, which deploys all Kata runtime classes, including NVIDIA-specific runtime classes.
    The ``kata-qemu-nvidia-gpu`` runtime class is used with Kata Containers.
-#. Install the NVIDIA GPU Operator with Kata sandbox mode enabled. 
+#. Install the NVIDIA GPU Operator with Kata sandbox mode enabled.
 
 After installation, you can run a sample workload that uses the Kata runtime class.
 
@@ -225,7 +225,7 @@ Kubernetes Cluster
 
   Refer to the `Kata Containers documentation <https://github.com/kata-containers/kata-containers/blob/main/docs/use-cases/NVIDIA-GPU-passthrough-and-Kata-QEMU.md#kata-runtime>`_ for more details on the Kata runtime and VFIO cold-plug.
 
-* Increase kubelet image pull timeouts configuration to 20 minutes to avoid timeouts when pulling large images. 
+* Increase kubelet image pull timeouts configuration to 20 minutes to avoid timeouts when pulling large images.
   Kubelet can de-allocate your pod if the image pull exceeds the configured timeout before the container transitions to the running state.
 
   Increase ``runtimeRequestTimeout`` in your `kubelet configuration <https://kubernetes.io/docs/tasks/administer-cluster/kubelet-config-file/>`_ to ``20m`` to match the default values for the Kata shim configurations in Kata Containers.
@@ -246,8 +246,8 @@ Kubernetes Cluster
 
      $ sudo systemctl restart kubelet
 
-  If you need a timeout of more than 1200 seconds (20 minutes), you will also need to adjust the Kata Agent's ``image_pull_timeout``, which defaults to 1200s. 
-  This setting also sets the confidential data hub's image pull API timeout in seconds. 
+  If you need a timeout of more than 1200 seconds (20 minutes), you will also need to adjust the Kata Agent's ``image_pull_timeout``, which defaults to 1200s.
+  This setting also sets the confidential data hub's image pull API timeout in seconds.
   To do this, add the ``agent.image_pull_timeout`` kernel parameter to your shim configuration, or pass an explicit value in a pod annotation in the ``io.katacontainers.config.hypervisor.kernel_params: "..."`` annotation.
 
 .. _label-nodes-kata-containers:
@@ -322,7 +322,11 @@ The minimum required version is ${kata_version}.
       $ helm install kata-deploy "${CHART}" \
          --namespace kata-system --create-namespace \
          --set nfd.enabled=false \
+         -f kata-nvidia-gpu-values.yaml \
          --version "${VERSION}"
+
+   The sample `kata-nvidia-gpu-values.yaml` file is included in the GitHub repository at
+   https://github.com/NVIDIA/cloud-native-docs/blob/main/confidential-containers/samples/kata-nvidia-gpu-values.yaml.
 
    *Example Output:*
 
@@ -660,8 +664,8 @@ If the sample workload does not run, confirm that you labeled nodes to run virtu
 .. code-block:: output
 
    NAME               STATUS   ROLES    AGE   VERSION
-   kata-worker-1      Ready    <none>   10d   v1.35.3 
-   kata-worker-2      Ready    <none>   10d   v1.35.3 
+   kata-worker-1      Ready    <none>   10d   v1.35.3
+   kata-worker-2      Ready    <none>   10d   v1.35.3
    kata-worker-3      Ready    <none>   10d   v1.35.3
 
 You might have configured ``vm-passthrough`` as the default sandbox workload in the ClusterPolicy resource.
@@ -680,4 +684,3 @@ Also confirm in the ClusterPolicy that ``sandboxWorkloads`` is configured for Ka
      enabled: true
      defaultWorkload: vm-passthrough
      mode: kata
-

--- a/repo.toml
+++ b/repo.toml
@@ -172,7 +172,7 @@ docs_root = "${root}/gpu-operator"
 project = "gpu-operator"
 name = "NVIDIA GPU Operator"
 version = "26.3"  # Update repo_docs.projects.openshift.version to match latest patch version maj.min.patch
-source_substitutions = { minor_version = "26.3", version = "v26.3.1", recommended = "580.126.20", dra_version = "25.12.0" }
+source_substitutions = { minor_version = "26.3", version = "v26.3.1", recommended = "580.126.20", dra_version = "25.12.0", kata_version = "3.31.0" }
 copyright_start = 2020
 sphinx_exclude_patterns = [
   "life-cycle-policy.rst",
@@ -209,7 +209,8 @@ output_format = "linkcheck"
 docs_root = "${root}/confidential-containers"
 project = "confidential-containers"
 name = "NVIDIA Confidential Containers Architecture"
-version = "1.0.0"
+version = "1.1.0"
+source_substitutions = { kata_version = "3.31.0", gpu_operator_version = "v26.3.1", gpu_operator_minor_version = "26.3" }
 copyright_start = 2020
 
 [repo_docs.projects.confidential-containers.builds.linkcheck]

--- a/repo.toml
+++ b/repo.toml
@@ -176,7 +176,7 @@ docs_root = "${root}/gpu-operator"
 project = "gpu-operator"
 name = "NVIDIA GPU Operator"
 version = "26.3"  # Update repo_docs.projects.openshift.version to match latest patch version maj.min.patch
-source_substitutions = { minor_version = "26.3", version = "v26.3.3", recommended = "580.173.02", dra_version = "0.4.1", kata_version = "3.31.0" }
+source_substitutions = { minor_version = "26.3", version = "v26.3.3", recommended = "580.173.02", dra_version = "0.4.1", kata_version = "4.0.0" }
 copyright_start = 2020
 sphinx_exclude_patterns = [
   "life-cycle-policy.rst",

--- a/repo.toml
+++ b/repo.toml
@@ -214,7 +214,7 @@ docs_root = "${root}/confidential-containers"
 project = "confidential-containers"
 name = "NVIDIA Confidential Containers Architecture"
 version = "1.1.0"
-source_substitutions = { kata_version = "3.31.0", gpu_operator_version = "v26.3.1", gpu_operator_minor_version = "26.3" }
+source_substitutions = { kata_version = "4.0.0", gpu_operator_version = "v26.3.1", gpu_operator_minor_version = "26.3" }
 copyright_start = 2020
 
 [repo_docs.projects.confidential-containers.builds.linkcheck]

--- a/repo.toml
+++ b/repo.toml
@@ -176,7 +176,7 @@ docs_root = "${root}/gpu-operator"
 project = "gpu-operator"
 name = "NVIDIA GPU Operator"
 version = "26.3"  # Update repo_docs.projects.openshift.version to match latest patch version maj.min.patch
-source_substitutions = { minor_version = "26.3", version = "v26.3.3", recommended = "580.173.02", dra_version = "0.4.1" }
+source_substitutions = { minor_version = "26.3", version = "v26.3.3", recommended = "580.173.02", dra_version = "0.4.1", kata_version = "3.31.0" }
 copyright_start = 2020
 sphinx_exclude_patterns = [
   "life-cycle-policy.rst",
@@ -213,7 +213,8 @@ output_format = "linkcheck"
 docs_root = "${root}/confidential-containers"
 project = "confidential-containers"
 name = "NVIDIA Confidential Containers Architecture"
-version = "1.0.0"
+version = "1.1.0"
+source_substitutions = { kata_version = "3.31.0", gpu_operator_version = "v26.3.1", gpu_operator_minor_version = "26.3" }
 copyright_start = 2020
 
 [repo_docs.projects.confidential-containers.builds.linkcheck]


### PR DESCRIPTION
[RNs](https://nvidia.github.io/cloud-native-docs/review/pr-408/confidential-containers/latest/release-notes.html#coco-v1-1-0), untouched from Abbie's update.  Crystal clear.

Containerd 2.3.x req in a [single place](https://nvidia.github.io/cloud-native-docs/review/pr-408/confidential-containers/latest/supported-platforms.html#supported-software-components) on the supported platforms page.

Abbie made some intervening enhancements, btw.
