### PR TITLE
Update docs to link to partner validated docs

### DIFF
--- a/gpu-operator/index.rst
+++ b/gpu-operator/index.rst
@@ -83,6 +83,7 @@
    Azure AKS <microsoft-aks.rst>
    Google GKE <google-gke.rst>
    NVIDIA GPU Operator on Red Hat OpenShift Container Platform <https://docs.nvidia.com/datacenter/cloud-native/openshift/latest/index.html>
+   Partner Validated <https://docs.nvidia.com/datacenter/cloud-native/partner-validated/latest/index.html>
 
 
 .. include:: overview.rst

--- a/gpu-operator/platform-support.rst
+++ b/gpu-operator/platform-support.rst
@@ -290,6 +290,8 @@ Supported Operating Systems and Kubernetes Platforms
 .. |fn2| replace:: :sup:`2`
 .. _fn3: #rhel-9
 .. |fn3| replace:: :sup:`3`
+.. _fn4: #partner-validated
+.. |fn4| replace:: :sup:`4`
 
 The GPU Operator has been validated in the following scenarios:
 
@@ -310,10 +312,10 @@ The GPU Operator has been validated in the following scenarios:
            | OpenShift
          - | VMware vSphere 
            | Kubernetes Service (VKS)
-         - | Rancher Kubernetes
-           | Engine 2 
+         - | Rancher Kubernetes 
+           | Engine 2 |fn4|_
          - | K3s
-         - | Mirantis k0s 
+         - | Mirantis k0s |fn4|_
          - | Canonical
            | MicroK8s 
          - | Nutanix
@@ -441,6 +443,11 @@ The GPU Operator has been validated in the following scenarios:
     .. note::
 
       |ocp_csp_support|
+
+    .. _partner-validated:
+
+    :sup:`4`
+    Refer to the `Partner Validated <https://docs.nvidia.com/datacenter/cloud-native/partner-validated/latest/index.html>`__ documentation for more information on these configurations
 
   .. tab-item:: Cloud Service Providers
     :sync: cloud-service-providers

--- a/gpu-operator/platform-support.rst
+++ b/gpu-operator/platform-support.rst
@@ -447,7 +447,7 @@ The GPU Operator has been validated in the following scenarios:
     .. _partner-validated:
 
     :sup:`4`
-    Refer to the `Partner Validated <https://docs.nvidia.com/datacenter/cloud-native/partner-validated/latest/index.html>`__ documentation for more information on these configurations
+    Refer to the `Partner Validated <https://docs.nvidia.com/datacenter/cloud-native/partner-validated/latest/index.html>`__ documentation for information on other operating systems support.
 
   .. tab-item:: Cloud Service Providers
     :sync: cloud-service-providers

--- a/partner-validated/index.rst
+++ b/partner-validated/index.rst
@@ -30,6 +30,7 @@ About Partner-Validated Configurations
    k0rdent.rst
    mirantis-mke.rst
    suse-rke2.rst
+   NVIDIA GPU Operator Documentation <https://docs.nvidia.com/datacenter/cloud-native/gpu-operator/latest/index.html>
 
 Partner-validated configurations help end users who want to use
 NVIDIA GPUs with a Kubernetes-based software stack that is not supported by NVIDIA.


### PR DESCRIPTION
Updates the platform support page to include a note about reviewing the partner validated docs, and a link from the partner validated page that points to the main GPU Operator docs.