### PR TITLE
Fix nvidia-cdi-refresh location, style guide update

### DIFF
--- a/container-toolkit/arch-overview.md
+++ b/container-toolkit/arch-overview.md
@@ -6,7 +6,7 @@
 
 # Architecture Overview
 
-The NVIDIA container stack is architected so that it can be targeted to support any container runtime in the ecosystem.
+The NVIDIA container stack is designed to support any container runtime in the ecosystem.
 The components of the stack include:
 
 - The NVIDIA Container Runtime (`nvidia-container-runtime`)
@@ -16,21 +16,21 @@ The components of the stack include:
 The components of the NVIDIA container stack are packaged as the NVIDIA Container Toolkit.
 
 How these components are used depends on the container runtime being used. For `docker` or `containerd`, the NVIDIA Container Runtime (`nvidia-container-runtime`) is
-configured as an OCI-compliant runtime, with the flow through the various components is shown in the following diagram:
+configured as an OCI-compliant runtime. The flow through the components is shown in the following diagram:
 
 ```{image} assets/runtime-architecture.png
 :width: 800
 ```
 
-The flow through components for `cri-o` and `lxc` are shown in the following diagram. It should be noted that in this
-case the NVIDIA Container Runtime component is not required.
+The flow through components for `cri-o` and `lxc` is shown in the following diagram. In this
+case, the NVIDIA Container Runtime component is not required.
 
 ```{image} assets/nvidia-crio-lxc-arch.png
 :width: 800
 ```
 
-Let's take a brief look at each of the components in the NVIDIA container stack, starting
-with the lowest level component and working up
+The following sections describe each component in the NVIDIA container stack, starting
+with the lowest-level component and working up.
 
 ## Components and Packages
 
@@ -53,20 +53,20 @@ With the dependencies between these packages shown below:
 └─ libnvidia-container1 (version)
 ```
 
-where `version` is used to represent the NVIDIA Container Toolkit version.
+where `version` represents the NVIDIA Container Toolkit version.
 
 :::{note}
-In the past the `nvidia-docker2` and `nvidia-container-runtime` packages were also discussed as part of the NVIDIA container stack.
+In the past, the `nvidia-docker2` and `nvidia-container-runtime` packages were also discussed as part of the NVIDIA container stack.
 These **packages** should be considered deprecated as their functionality has been merged with the `nvidia-container-toolkit` package.
-The packages may still be available to introduce dependencies on `nvidia-container-toolkit` and ensure that older workflows continue to function.
-For more information on these packages, see the documentation archive for version older than `v1.12.0`.
+The packages might still be available to introduce dependencies on `nvidia-container-toolkit` and ensure that older workflows continue to function.
+For more information on these packages, refer to the documentation archive for versions older than `v1.12.0`.
 :::
 
 ### The NVIDIA Container Library and CLI
 
 These components are packaged as the `libnvidia-container-tools` and `libnvidia-container1` packages, respectively.
 
-These components provide a library and a simple CLI utility to automatically configure GNU/Linux containers leveraging NVIDIA GPUs.
+These components provide a library and a CLI utility to automatically configure GNU/Linux containers that use NVIDIA GPUs.
 The implementation relies on kernel primitives and is designed to be agnostic of the container runtime.
 
 `libnvidia-container` provides a well-defined API and a wrapper CLI (called `nvidia-container-cli`) that different runtimes can invoke to
@@ -76,11 +76,11 @@ inject NVIDIA GPU support into their containers.
 
 This component is included in the `nvidia-container-toolkit` package.
 
-This component includes an executable that implements the interface required by a `runC` `prestart` hook. This script is invoked by `runC`
-after a container has been created, but before it has been started, and is given access to the `config.json` associated with the container
+This component includes an executable that implements the interface required by a `runC` `prestart` hook. `runC` invokes this script
+after a container is created but before it starts, and gives it access to the `config.json` associated with the container
 (such as this [config.json](https://github.com/opencontainers/runtime-spec/blob/master/config.md#configuration-schema-example=) ). It then takes
 information contained in the `config.json` and uses it to invoke the `nvidia-container-cli` CLI with an appropriate set of flags. One of the
-most important flags being which specific GPU devices should be injected into the container.
+most important flags is which specific GPU devices to inject into the container.
 
 ### The NVIDIA Container Runtime
 
@@ -92,19 +92,19 @@ a `prestart` hook into it, and then calls out to the native `runC`, passing it t
 For versions of the NVIDIA Container Runtime from `v1.12.0`, this runtime also performs additional modifications to the OCI runtime spec to inject
 specific devices and mounts not handled by the NVIDIA Container CLI.
 
-It is important to note that this component is not necessarily specific to docker (but it is specific to `runC`).
+This component is not necessarily specific to Docker, but it is specific to `runC`.
 
 ### The NVIDIA Container Toolkit CLI
 
 This component is included in the `nvidia-container-toolkit-base` package.
 
-This component is a CLI that includes a number of utilities for interacting with the NVIDIA Container Toolkit. This functionality includes configuring
+This component is a CLI that includes several utilities for interacting with the NVIDIA Container Toolkit. This functionality includes configuring
 runtimes such as `docker` for use with the NVIDIA Container Toolkit or generating [Container Device Interface (CDI)](https://github.com/container-orchestrated-devices/container-device-interface) specifications.
 
-## Which package should I use then?
+## Which Package to Use
 
 Installing the `nvidia-container-toolkit` package is sufficient for all use cases. This
-package is continuously being enhanced with additional functionality and tools that simplify working with containers and
+package is continuously enhanced with functionality and tools that simplify working with containers and
 NVIDIA devices.
 
 To use Kubernetes with Docker, you need to configure the Docker `daemon.json` to include
@@ -115,8 +115,8 @@ Refer to the {doc}`install-guide` for more information on installing the NVIDIA 
 
 ### Package Repository
 
-The packages for the various components listed above are available in the `gh-pages` branch of the GitHub repos of these projects. This is particularly
-useful for air-gapped deployments that may want to get access to the actual packages (`.deb` and `.rpm`) to support offline installs.
+The packages for the components listed above are available in the `gh-pages` branch of the GitHub repos of these projects. This is
+useful for air-gapped deployments that need access to the packages (`.deb` and `.rpm`) to support offline installs.
 
 For the different components:
 
@@ -129,10 +129,10 @@ For the different components:
    - `https://github.com/NVIDIA/libnvidia-container/tree/gh-pages/`
 
 :::{note}
-As of the release of version `1.6.0` of the NVIDIA Container Toolkit the packages for all components are
-published to the `libnvidia-container` `repository <https://nvidia.github.io/libnvidia-container/>` listed above. For older package versions refer to the documentation archives.
+As of the release of version `1.6.0` of the NVIDIA Container Toolkit, the packages for all components are
+published to the `libnvidia-container` `repository <https://nvidia.github.io/libnvidia-container/>` listed above. For older package versions, refer to the documentation archives.
 :::
 
-Releases of the software are also hosted on `experimental` branch of the repository and are graduated to `stable` after test/validation. To get access to the latest
-`experimental` features of the NVIDIA Container Toolkit, you may need to add the `experimental` branch to the `apt` or `yum` repository listing. The installation instructions
+Releases of the software are also hosted on the `experimental` branch of the repository and are graduated to `stable` after testing and validation. To get access to the latest
+`experimental` features of the NVIDIA Container Toolkit, you might need to add the `experimental` branch to the `apt` or `yum` repository listing. The installation instructions
 include information on how to add these repository listings for the package manager.

--- a/container-toolkit/cdi-support.md
+++ b/container-toolkit/cdi-support.md
@@ -11,7 +11,7 @@
 
 ## About the Container Device Interface
 
-As of the `v1.12.0` release the NVIDIA Container Toolkit includes support for generating Container Device Interface (CDI) specifications.
+As of the `v1.12.0` release, the NVIDIA Container Toolkit includes support for generating Container Device Interface (CDI) specifications.
 
 CDI is an open specification for container runtimes that abstracts what *access* to a device, such as an NVIDIA GPU, means, and standardizes access across container runtimes.
 Popular container runtimes can read and process the specification to ensure that a device is available in a container.
@@ -19,7 +19,7 @@ CDI simplifies adding support for devices such as NVIDIA GPUs because the specif
 
 CDI also improves the compatibility of the NVIDIA container stack with certain features such as rootless containers.
 
-## Generating a CDI specification
+## Generating a CDI Specification
 
 ### Prerequisites
 
@@ -42,15 +42,15 @@ As of NVIDIA Container Toolkit `v1.18.0`, the CDI specification is automatically
   - The system is rebooted
 
 This ensures that the CDI specifications are up to date for the current driver
-and device configuration and that CDI Devices defined in these speciciations are
+and device configuration and that CDI Devices defined in these specifications are
 available when using native CDI support in container engines such as Docker or Podman.
 
-Running the following command will give a list of availble CDI Devices:
+Run the following command to list the available CDI Devices:
 ```console
 nvidia-ctk cdi list
 ```
 
-#### Known limitations
+#### Known Limitations
 The `nvidia-cdi-refresh` service does not currently handle the following situations:
 
 - The removal of NVIDIA GPU drivers
@@ -59,21 +59,21 @@ The `nvidia-cdi-refresh` service does not currently handle the following situati
 For these scenarios, the regeneration of CDI specifications must be [manually triggered](#manual-cdi-specification-generation).
 
 #### Customizing the Automatic CDI Refresh Service
-The behavior of the `nvidia-cdi-refresh` service can be customized by adding
-environment variables to `/etc/nvidia-container-toolkit/cdi-refresh.env` to
-affect the behavior of the `nvidia-ctk cdi generate` command.
+To customize the behavior of the `nvidia-cdi-refresh` service, add
+environment variables to `/etc/nvidia-container-toolkit/nvidia-cdi-refresh.env`. These
+variables affect the behavior of the `nvidia-ctk cdi generate` command.
 
-As an example, to enable debug logging the configuration file should be updated
+For example, to enable debug logging, update the configuration file
 as follows:
 ```bash
-# /etc/nvidia-container-toolkit/cdi-refresh.env
+# /etc/nvidia-container-toolkit/nvidia-cdi-refresh.env
 NVIDIA_CTK_DEBUG=1
 ```
 
-For a complete list of available environment variables, run `nvidia-ctk cdi generate --help` to see the command's documentation.
+For a complete list of available environment variables, run `nvidia-ctk cdi generate --help` to view the command's documentation.
 
 ```{important}
-Modifications to the environment file required a systemd reload and restarting the
+Modifications to the environment file require a systemd reload and restarting the
 service to take effect
 ```
 
@@ -92,8 +92,8 @@ The `nvidia-cdi-refresh` service consists of two systemd units:
 
 These services can be managed using standard systemd commands.
 
-When working as expected, the `nvidia-cdi-refresh.path` service will be enabled and active, and the
-`nvidia-cdi-refresh.service` will be enabled and have run at least once. For example:
+When working as expected, the `nvidia-cdi-refresh.path` service is enabled and active, and the
+`nvidia-cdi-refresh.service` is enabled and has run at least once. For example:
 
 ```console
 $ sudo systemctl status nvidia-cdi-refresh.path
@@ -115,7 +115,7 @@ TriggeredBy: ● nvidia-cdi-refresh.path
 ...
 ```
 
-If these are not enabled as expected, they can be enabled by running:
+If these are not enabled as expected, enable them by running:
 
 ```console
 $ sudo systemctl enable --now nvidia-cdi-refresh.path
@@ -124,9 +124,8 @@ $ sudo systemctl enable --now nvidia-cdi-refresh.service
 
 #### Troubleshooting CDI Specification Generation and Resolution
 
-If CDI specifications for available devices are not generated / updated as expected, it is
-recommended that the logs for the `nvidia-cdi-refresh.service` be checked. This can be
-done by running:
+If CDI specifications for available devices are not generated or updated as expected,
+check the logs for the `nvidia-cdi-refresh.service` by running:
 
 ```console
 $ sudo journalctl -u nvidia-cdi-refresh.service
@@ -144,19 +143,19 @@ Running:
 ```console
 $ nvidia-ctk --debug cdi list
 ```
-will show a list of available CDI Devices as well as any errors that may have
-occurred when loading CDI Specifications from `/etc/cdi` or `/var/run/cdi`.
+Shows a list of available CDI Devices and any errors that occurred when loading CDI
+Specifications from `/etc/cdi` or `/var/run/cdi`.
 
 ### Manual CDI Specification Generation
 
-As of the NVIDIA Container Toolkit `v1.18.0` the recommended mechanism to regenerate CDI specifications is to restart the `nvidia-cdi-refresh.service`:
+As of the NVIDIA Container Toolkit `v1.18.0`, the recommended mechanism to regenerate CDI specifications is to restart the `nvidia-cdi-refresh.service`:
 
 ```console
 $ sudo systemctl restart nvidia-cdi-refresh.service
 ```
 
-If this does not work, or more flexibility is required, the `nvidia-ctk cdi generate` command
-can be used directly:
+If this does not work, or you need more flexibility, use the `nvidia-ctk cdi generate` command
+directly:
 
 ```console
 $ sudo nvidia-ctk cdi generate --output=/var/run/cdi/nvidia.yaml
@@ -168,9 +167,9 @@ Using CDI to inject NVIDIA devices can conflict with using the NVIDIA Container 
 This means that if a `/usr/share/containers/oci/hooks.d/oci-nvidia-hook.json` file exists, delete it
 or ensure that you do not run containers with the `NVIDIA_VISIBLE_DEVICES` environment variable set.
 
-The use of the CDI specification is dependent on the CDI-enabled container engine or CLI that you use.
+The use of the CDI specification depends on the CDI-enabled container engine or CLI that you use.
 In the case of `podman`, for example, releases as of `v4.1.0` include support for specifying CDI devices in the `--device` argument.
-Assuming that you generated a CDI specification as in the preceding section, running a container with access to all NVIDIA GPUs would require the following command:
+Assuming that you generated a CDI specification as in the preceding section, running a container with access to all NVIDIA GPUs requires the following command:
 
 ```console
 $ podman run --rm --device nvidia.com/gpu=all --security-opt=label=disable ubuntu nvidia-smi -L

--- a/container-toolkit/docker-specialized.md
+++ b/container-toolkit/docker-specialized.md
@@ -4,17 +4,17 @@
 
 # Specialized Configurations with Docker
 
-## Environment variables (OCI spec)
+## Environment Variables (OCI Spec)
 
-Users can control the behavior of the NVIDIA container runtime using environment variables - especially for
+You can control the behavior of the NVIDIA Container Runtime using environment variables, especially for
 enumerating the GPUs and the capabilities of the driver.
-Each environment variable maps to an command-line argument for `nvidia-container-cli` from [libnvidia-container](https://github.com/NVIDIA/libnvidia-container).
-These variables are already set in the NVIDIA provided base [CUDA images](https://ngc.nvidia.com/catalog/containers/nvidia:cuda).
+Each environment variable maps to a command-line argument for `nvidia-container-cli` from [libnvidia-container](https://github.com/NVIDIA/libnvidia-container).
+These variables are already set in the NVIDIA-provided base [CUDA images](https://ngc.nvidia.com/catalog/containers/nvidia:cuda).
 
 ### GPU Enumeration
 
-GPUs can be specified to the Docker CLI using either the `--gpus` option starting with Docker `19.03` or using the environment variable
-`NVIDIA_VISIBLE_DEVICES`. This variable controls which GPUs will be made accessible inside the container.
+You can specify GPUs to the Docker CLI using either the `--gpus` option starting with Docker `19.03` or the environment variable
+`NVIDIA_VISIBLE_DEVICES`. This variable controls which GPUs are accessible inside the container.
 
 The possible values of the `NVIDIA_VISIBLE_DEVICES` variable are:
 
@@ -30,45 +30,45 @@ The possible values of the `NVIDIA_VISIBLE_DEVICES` variable are:
       - a comma-separated list of GPU UUID(s) or index(es).
 
     * - ``all``
-      - all GPUs will be accessible, this is the default value in base CUDA container images.
+      - All GPUs are accessible. This is the default value in base CUDA container images.
 
     * - ``none``
-      - no GPU will be accessible, but driver capabilities will be enabled.
+      - No GPU is accessible, but driver capabilities are enabled.
 
     * - ``void`` or `empty` or `unset`
-      - ``nvidia-container-runtime`` will have the same behavior as ``runc`` (i.e. neither GPUs nor capabilities are exposed)
+      - ``nvidia-container-runtime`` has the same behavior as ``runc`` (that is, neither GPUs nor capabilities are exposed).
 ```
 
 :::{note}
-When using the `--gpus` option to specify the GPUs, the `device` parameter should be used. This is shown in the examples below.
-The format of the `device` parameter should be encapsulated within single quotes, followed by double quotes for the devices you
-want enumerated to the container. For example: `'"device=2,3"'` will enumerate GPUs 2 and 3 to the container.
+When using the `--gpus` option to specify the GPUs, use the `device` parameter, as shown in the following examples.
+Encapsulate the format of the `device` parameter within single quotes, followed by double quotes for the devices you
+want enumerated to the container. For example, `'"device=2,3"'` enumerates GPUs 2 and 3 to the container.
 
-When using the NVIDIA_VISIBLE_DEVICES variable, you may need to set `--runtime` to `nvidia` unless already set as default.
+When using the NVIDIA_VISIBLE_DEVICES variable, you might need to set `--runtime` to `nvidia` unless it is already set as the default.
 :::
 
-Some examples of the usage are shown below:
+The following examples show common usage:
 
-1. Starting a GPU enabled CUDA container; using `--gpus`
+1. Start a GPU-enabled CUDA container using `--gpus`:
 
    ```console
    $ docker run --rm --gpus all nvidia/cuda nvidia-smi
    ```
 
-2. Using `NVIDIA_VISIBLE_DEVICES` and specify the nvidia runtime
+2. Use `NVIDIA_VISIBLE_DEVICES` and specify the NVIDIA runtime:
 
    ```console
    $ docker run --rm --runtime=nvidia \
        -e NVIDIA_VISIBLE_DEVICES=all nvidia/cuda nvidia-smi
    ```
 
-3. Start a GPU enabled container on two GPUs
+3. Start a GPU-enabled container on two GPUs:
 
    ```console
    $ docker run --rm --gpus 2 nvidia/cuda nvidia-smi
    ```
 
-4. Starting a GPU enabled container on specific GPUs
+4. Start a GPU-enabled container on specific GPUs:
 
    ```console
    $ docker run --gpus '"device=1,2"' \
@@ -81,7 +81,7 @@ Some examples of the usage are shown below:
    GPU-16a23983-e73e-0945-2095-cdeb50696982
    ```
 
-5. Alternatively, you can also use `NVIDIA_VISIBLE_DEVICES`
+5. Alternatively, use `NVIDIA_VISIBLE_DEVICES`:
 
    ```console
    $ docker run --rm --runtime=nvidia \
@@ -95,7 +95,7 @@ Some examples of the usage are shown below:
    GPU-16a23983-e73e-0945-2095-cdeb50696982
    ```
 
-6. Query the GPU UUID using `nvidia-smi` and then specify that to the container
+6. Query the GPU UUID using `nvidia-smi`, then specify it to the container:
 
    ```console
    $ nvidia-smi -i 3 --query-gpu=uuid --format=csv
@@ -113,7 +113,7 @@ Some examples of the usage are shown below:
 
 ### Driver Capabilities
 
-The `NVIDIA_DRIVER_CAPABILITIES` controls which driver libraries/binaries will be mounted inside the container.
+The `NVIDIA_DRIVER_CAPABILITIES` variable controls which driver libraries and binaries are mounted inside the container.
 
 The possible values of the `NVIDIA_DRIVER_CAPABILITIES` variable are:
 
@@ -135,7 +135,7 @@ The possible values of the `NVIDIA_DRIVER_CAPABILITIES` variable are:
       - use default driver capability: ``utility``, ``compute``
 ```
 
-The supported driver capabilities are provided below:
+The following table describes the supported driver capabilities:
 
 ```{eval-rst}
 .. list-table::
@@ -164,7 +164,7 @@ The supported driver capabilities are provided below:
       - required for leveraging X11 display.
 ```
 
-For example, specify the `compute` and `utility` capabilities, allowing usage of CUDA and NVML
+For example, to allow usage of CUDA and NVML, specify the `compute` and `utility` capabilities:
 
 > ```console
 > $ docker run --rm --runtime=nvidia \
@@ -180,13 +180,13 @@ For example, specify the `compute` and `utility` capabilities, allowing usage of
 
 ### Constraints
 
-The NVIDIA runtime also provides the ability to define constraints on the configurations supported by the container.
+The NVIDIA runtime also lets you define constraints on the configurations that the container supports.
 
 #### NVIDIA_REQUIRE_* Constraints
 
 This variable is a logical expression to define constraints on the software versions or GPU architectures on the container.
 
-The supported constraints are provided below:
+The following table describes the supported constraints:
 
 ```{eval-rst}
 .. list-table::
@@ -225,23 +225,23 @@ NVIDIA_REQUIRE_CUDA "cuda>=11.0 driver>=450"
 Single switch to disable all the constraints of the form `NVIDIA_REQUIRE_*`.
 
 :::{note}
-If you are running CUDA-base images older than CUDA 11.7 (and unable to update to the new base images with updated constraints),
-CUDA compatibility checks can be disabled by setting `NVIDIA_DISABLE_REQUIRE` to `true`.
+If you are running CUDA base images older than CUDA 11.7 and cannot update to the new base images with updated constraints,
+you can disable CUDA compatibility checks by setting `NVIDIA_DISABLE_REQUIRE` to `true`.
 :::
 
 #### NVIDIA_REQUIRE_CUDA Constraint
 
 The version of the CUDA toolkit used by the container. It is an instance of the
 generic `NVIDIA_REQUIRE_*` case and it is set by official CUDA images. If the version of the NVIDIA driver
-is insufficient to run this version of CUDA, the container will not be started. This variable
-can be specified in the form `major.minor`
+is insufficient to run this version of CUDA, the container does not start. This variable
+can be specified in the form `major.minor`.
 
-The possible values for this variable: `cuda>=7.5`, `cuda>=8.0`, `cuda>=9.0` and so on.
+The possible values for this variable are `cuda>=7.5`, `cuda>=8.0`, `cuda>=9.0`, and so on.
 
 ### Dockerfiles
 
-Capabilities and GPU enumeration can be set in images via environment variables. If the environment variables are
-set inside the Dockerfile, you don't need to set them on the `docker run` command-line.
+You can set capabilities and GPU enumeration in images using environment variables. If you
+set the environment variables inside the Dockerfile, you do not need to set them on the `docker run` command line.
 
 For instance, if you are creating your own custom CUDA container, you should use the following:
 
@@ -250,4 +250,4 @@ ENV NVIDIA_VISIBLE_DEVICES all
 ENV NVIDIA_DRIVER_CAPABILITIES compute,utility
 ```
 
-These environment variables are already set in the NVIDIA provided CUDA images.
+These environment variables are already set in the NVIDIA-provided CUDA images.

--- a/container-toolkit/index.md
+++ b/container-toolkit/index.md
@@ -23,7 +23,7 @@ Container Device Interface <cdi-support.md>
 docker-specialized.md
 ```
 
-The NVIDIA Container Toolkit is a collection of libraries and utilities enabling users to build and run GPU-accelerated containers. It currently includes:
+The NVIDIA Container Toolkit is a collection of libraries and utilities that enable you to build and run GPU-accelerated containers. It currently includes:
 
 * The NVIDIA Container Runtime (`nvidia-container-runtime`)
 * The NVIDIA Container Toolkit CLI (`nvidia-ctk`)

--- a/container-toolkit/install-guide.md
+++ b/container-toolkit/install-guide.md
@@ -10,7 +10,7 @@
 
 ### Prerequisites
 
-1. Read [this section](./supported-platforms.md) about platform support.
+1. Review the [platform support documentation](./supported-platforms.md).
 
 2. Install the NVIDIA GPU driver for your Linux distribution.
 NVIDIA recommends installing the driver by using the package manager for your distribution.
@@ -168,7 +168,7 @@ where `systemd` cgroup drivers are used that cause containers to lose access to 
    $ sudo systemctl restart docker
    ```
 
-#### Rootless mode
+#### Rootless Mode
 
 To configure the container runtime for Docker running in [Rootless mode](https://docs.docker.com/engine/security/rootless/),
 follow these steps:
@@ -213,7 +213,7 @@ follow these steps:
 ### Configuring containerd (for nerdctl)
 
 No additional configuration is needed.
-You can just run `nerdctl run --gpus=all`, with root or without root.
+You can run `nerdctl run --gpus=all`, with or without root.
 You do not need to run the `nvidia-ctk` command mentioned above for Kubernetes.
 
 Refer to the [nerdctl documentation](https://github.com/containerd/nerdctl/blob/main/docs/gpu.md) for more information.

--- a/container-toolkit/sample-workload.md
+++ b/container-toolkit/sample-workload.md
@@ -11,7 +11,7 @@ you can verify your installation by running a sample workload.
    sudo docker run --rm --runtime=nvidia --gpus all ubuntu nvidia-smi
    ```
 
-   Your output should resemble the following output:
+   Your output should resemble the following:
 
    ```{literalinclude} ./output/nvidia-smi.txt
    ---
@@ -32,7 +32,7 @@ you can verify your installation by running a sample workload.
       ubuntu nvidia-smi
    ```
 
-   Your output should resemble the following output:
+   Your output should resemble the following:
 
    ```{literalinclude} ./output/nvidia-smi.txt
    ---

--- a/container-toolkit/supported-platforms.md
+++ b/container-toolkit/supported-platforms.md
@@ -4,7 +4,7 @@
 
 (supported-platforms)=
 
-# Platform support
+# Platform Support
 
 Recent NVIDIA Container Toolkit releases are tested and expected to work on these Linux distributions:
 
@@ -23,17 +23,17 @@ Recent NVIDIA Container Toolkit releases are tested and expected to work on thes
 | Rocky Linux 9.7          | X              | X       | X                        |
 
 
-## Report issues
+## Report Issues
 
-Our qualification-testing procedures are constantly evolving and we might miss
-certain problems. [Report](https://github.com/NVIDIA/nvidia-container-toolkit/issues) issues in
-particular as they occur on a platform listed above.
+NVIDIA qualification-testing procedures are continually evolving and might miss
+some problems. [Report issues on GitHub](https://github.com/NVIDIA/nvidia-container-toolkit/issues),
+in particular those that occur on a platform listed in the table.
 
 
-## Other Linux distributions
+## Other Linux Distributions
 
-Releases may work on more platforms than indicated in the table above (such as on distribution versions older and newer than listed).
-Give things a try and we invite you to [report](https://github.com/NVIDIA/nvidia-container-toolkit/issues) any issue observed even if your Linux distribution is not listed.
+Releases can work on more platforms than indicated in the table above, such as distribution versions older and newer than those listed.
+You can still try them and [report any issue](https://github.com/NVIDIA/nvidia-container-toolkit/issues) you observe, even if your Linux distribution is not listed.
 
 ----
 

--- a/container-toolkit/troubleshooting.md
+++ b/container-toolkit/troubleshooting.md
@@ -11,7 +11,7 @@
 ### Generating Debugging Logs
 
 For most common issues, you can generate debugging logs to help identify the root cause of the problem.
-To generate debug logs :
+To generate debug logs:
 
 - Edit your runtime configuration under `/etc/nvidia-container-runtime/config.toml` and uncomment the `debug=...` line.
 - Run your container again to reproduce the issue and generate the logs.
@@ -20,12 +20,12 @@ To generate debug logs :
 
 In the event of a critical failure, core dumps can be automatically generated and can help troubleshoot issues.
 Refer to [core(5)](http://man7.org/linux/man-pages/man5/core.5.html) to generate these.
-In particular make check the following items:
+In particular, check the following items:
 
 - `/proc/sys/kernel/core_pattern` is correctly set and points somewhere with write access.
 - `ulimit -c` is set to a sensible default.
 
-In case the `nvidia-container-cli` process becomes unresponsive, [gcore(1)](http://man7.org/linux/man-pages/man1/gcore.1.html) can also be used.
+If the `nvidia-container-cli` process becomes unresponsive, you can also use [gcore(1)](http://man7.org/linux/man-pages/man1/gcore.1.html).
 
 ### Sharing Your Debugging Information
 
@@ -36,7 +36,7 @@ into the comment section.
 
 ## Conflicting values set for option Signed-By error when running apt update
 
-When following the installation instructions on Ubuntu or Debian-based systems and updating the package repository, the following error could be triggered:
+When following the installation instructions on Ubuntu or Debian-based systems and updating the package repository, you might see the following error:
 
 ```console
 $ sudo apt-get update
@@ -49,7 +49,7 @@ This is caused by the combination of two things:
 1. A recent update to the installation instructions to create a repo list file `/etc/apt/sources.list.d/nvidia-container-toolkit.list`
 2. The deprecation of `apt-key` meaning that the `signed-by` directive is included in the repo list file
 
-If this error is triggered it means that another reference to the same repository exists that does not specify the `signed-by` directive.
+If this error is triggered, it means that another reference to the same repository exists that does not specify the `signed-by` directive.
 The most likely candidates would be one or more of the files `libnvidia-container.list`, `nvidia-docker.list`, or `nvidia-container-runtime.list` in the
 folder `/etc/apt/sources.list.d/`.
 
@@ -69,8 +69,8 @@ Deleting the listed files should resolve the original error.
 
 ## Permission denied error when running the nvidia-docker wrapper under SELinux
 
-When running the `nvidia-docker` wrapper (provided by the `nvidia-docker2` package) on SELinux environments
-one may see the following error
+When running the `nvidia-docker` wrapper (provided by the `nvidia-docker2` package) on SELinux environments,
+you might see the following error:
 
 ```console
 $ sudo nvidia-docker run --gpus=all --rm nvcr.io/nvidia/cuda:11.6.2-base-ubuntu20.04 nvidia-smi
@@ -97,13 +97,13 @@ allow this access for now by executing:
 
 This occurs because `nvidia-docker` forwards the command line arguments with minor modifications to the `docker` executable.
 
-To address this, specify the NVIDIA runtime in the the `docker` command:
+To address this, specify the NVIDIA runtime in the `docker` command:
 
 ```console
 $ sudo docker run --gpus=all --runtime=nvidia --rm nvcr.io/nvidia/cuda:11.6.2-base-ubuntu20.04 nvidia-smi
 ```
 
-Alternatively a local SELinux policy can be generated as suggested:
+Alternatively, you can generate a local SELinux policy as suggested:
 
 ```console
 $ ausearch -c 'nvidia-docker' --raw | audit2allow -M my-nvidiadocker
@@ -114,10 +114,10 @@ $ semodule -X 300 -i my-nvidiadocker.pp
 
 Depending on how your Red Hat Enterprise Linux system is configured with SELinux, you might have to
 specify ``--security-opt=label=disable`` on the Docker or Podman command line to share parts of the
-host OS that can not be relabeled.
+host OS that cannot be relabeled.
 Without this option, you might observe this error when running GPU containers:
 ``Failed to initialize NVML: Insufficient Permissions``.
-However, using this option disables SELinux separation in the container and the container is executed
+However, using this option disables SELinux separation in the container, and the container runs
 in an unconfined type.
 Review the SELinux policies on your system.
 
@@ -127,32 +127,32 @@ Review the SELinux policies on your system.
 When using the NVIDIA Container Runtime Hook (that is, the Docker `--gpus` flag or
 the NVIDIA Container Runtime in `legacy` mode) to inject requested GPUs and driver
 libraries into a container, the hook makes modifications, including setting up cgroup access, to the container without the low-level runtime (such as `runc`) being aware of these changes.
-The result is that updates to the container may remove access to the requested GPUs.
+The result is that updates to the container can remove access to the requested GPUs.
 
-When the container loses access to the GPU, you will see the following error message from the console output:
+When the container loses access to the GPU, you see the following error message from the console output:
 
 ```console
 Failed to initialize NVML: Unknown Error
 ```
 
-The message may differ depending on the type of application that is running in
+The message can differ depending on the type of application that is running in
 the container.
 
-The container needs to be deleted once the issue occurs.
-When it is restarted, manually or automatically depending if you are using a container orchestration platform, it will regain access to the GPU.
+You need to delete the container after the issue occurs.
+When it is restarted, either manually or automatically depending on whether you use a container orchestration platform, it regains access to the GPU.
 
-### Affected environments
+### Affected Environments
 
-On certain systems this behavior is not limited to *explicit* container updates
-such as adjusting CPU and Memory limits for a container.
+On certain systems, this behavior is not limited to *explicit* container updates
+such as adjusting CPU and memory limits for a container.
 On systems where `systemd` is used to manage the cgroups of the container, reloading the `systemd` unit files (`systemctl daemon-reload`) is sufficient to trigger container updates and cause a loss of GPU access.
 
-### Mitigations and  Workarounds
+### Mitigations and Workarounds
 
 ```{warning}
 Certain `runc` versions show similar behavior with the `systemd` cgroup driver when `/dev/char` symlinks for the required devices are missing on the system.
-Refer to [GitHub disccusion #1133](https://github.com/NVIDIA/nvidia-container-toolkit/discussions/1133) for more details around this issue.
-It should be noted that the behavior persisted even if device nodes were requested on the command line.
+Refer to [GitHub discussion #1133](https://github.com/NVIDIA/nvidia-container-toolkit/discussions/1133) for more details around this issue.
+The behavior persisted even if device nodes were requested on the command line.
 Newer `runc` versions do not show this behavior and newer NVIDIA driver versions ensure that the required symlinks are present, reducing the likelihood of the specific issue occurring for affected `runc` versions.
 ```
 
@@ -165,11 +165,11 @@ Use the following workarounds to prevent containers from losing access to reques
   }
   ```
   and restart docker by running `systemctl restart docker`.
-  This will ensure that the container will not lose access to devices when `systemctl daemon-reload` is run.
-  This approach does not change the behavior for explicit container updates and a container will still lose access to devices in this case.
+  This ensures that the container does not lose access to devices when `systemctl daemon-reload` is run.
+  This approach does not change the behavior for explicit container updates, and a container still loses access to devices in this case.
 * Explicitly request the device nodes associated with the requested GPU(s) and any control device nodes when starting the container.
   For the Docker CLI, this is done by adding the relevant `--device` flags.
-  In the case of the NVIDIA Kubernetes Device Plugin the `compatWithCPUManager= true` [Helm option](https://github.com/NVIDIA/k8s-device-plugin?tab=readme-ov-file#setting-other-helm-chart-values) will ensure the same thing.
+  In the case of the NVIDIA Kubernetes Device Plugin, the `compatWithCPUManager= true` [Helm option](https://github.com/NVIDIA/k8s-device-plugin?tab=readme-ov-file#setting-other-helm-chart-values) ensures the same result.
 * Use the Container Device Interface (CDI) to inject devices into a container.
   When CDI is used to inject devices into a container, the required device nodes are included in the modifications made to the container config.
-  This means that even if the container is updated it will still have access to the required devices.
+  This means that even if the container is updated, it still has access to the required devices.


### PR DESCRIPTION
* Fixes file location to /etc/nvidia-container-toolkit/nvidia-cdi-refresh.env
* update docs to align with style guide.