### PR TITLE
docs: Def NVIDIA driver and migration

### DIFF
--- a/gpu-operator/gpu-driver-configuration.rst
+++ b/gpu-operator/gpu-driver-configuration.rst
@@ -31,14 +31,19 @@ to specify the NVIDIA GPU driver type and driver version to configure on specifi
 You can specify labels in the node selector field to control which NVIDIA driver configuration is applied to specific nodes.
 
 
-Limitations
-===========
+Driver Management Modes
+=======================
 
-* This feature is recommended for new cluster installations only.
-  Upgrades from ClusterPolicy managed drivers to NVIDIA driver custom resource managed drivers are not supported.
-  Switching from ClusterPolicy to the NVIDIA driver custom resource will cause all existing driver pods to be terminated immediately and redeployed using the new NVIDIADriver configuration.
-* You must either use the default NVIDIA driver custom resource that the Helm chart creates or create and manage your own custom NVIDIA driver custom resource.
-* You can't use ClusterPolicy and the NVIDIA driver custom resource at the same time. You can only use one or the other in a cluster.
+To use NVIDIA driver custom resources with a cluster policy custom resource, set
+``spec.driver.useNvidiaDriverCRD`` to ``true``.
+The cluster policy controller continues to manage the other GPU Operator operands, but delegates
+driver management to the NVIDIA driver custom resource controller.
+If ``spec.driver.useNvidiaDriverCRD`` is ``false``, the Operator does not reconcile
+NVIDIA driver custom resources.
+
+You can migrate a Helm installation from managing the driver with the cluster policy custom resource
+to managing it with NVIDIA driver custom resources.
+For the supported procedure, refer to `Migrating from Cluster Policy Driver Management`_.
 
 Comparison: Managing the Driver with CRD versus the Cluster Policy
 ==================================================================
@@ -87,26 +92,34 @@ About the Default NVIDIA Driver Custom Resource
 ===============================================
 
 By default, the Helm chart configures a default NVIDIA driver custom resource during installation.
-This custom resource does not include a node selector and as a result, the custom resource applies to every node in your cluster
-that has an NVIDIA GPU.
+The resource has ``spec.default: true`` and does not include a node selector.
+It acts as a fallback and applies to every GPU node that does not match the node selector of another
+NVIDIA driver custom resource.
 The Operator starts a driver daemon set and pods for each operating system version in your cluster.
 
-If you plan to configure your own driver custom resources to specify driver versions, types, and so on, then
-you might prefer to avoid installing the default custom resource.
-By preventing the installation, you can avoid node selector conflicts due to the default custom resource
-matching all nodes and your custom resources matching some of the same nodes.
+You can use the default resource and additional user-defined resources at the same time.
+A user-defined resource takes precedence on nodes that match its node selector, and the default resource
+continues to manage the remaining GPU nodes.
+User-defined resources must not select the same node.
+If they do, the affected resources report ``notReady`` with a ``ConflictingNodeSelector`` condition,
+and the Operator retains the existing driver ownership labels until you resolve the conflict.
 
-To prevent configuring the default custom resource, specify the ``--set driver.nvidiaDriverCRD.deployDefaultCR=false``
-argument when you install the Operator with Helm.
+Only one NVIDIA driver custom resource can have ``spec.default: true``.
+A default resource cannot specify ``spec.nodeSelector`` because it would not be able to act as a fallback.
+If more than one default resource exists, the Operator marks the affected resources ``notReady`` with a
+``ReconcileFailed`` condition and does not change the existing driver ownership labels on nodes.
+Delete or update the extra default resource to resume reconciliation.
 
-If the Operator is already installed with the default custom resource and you want to create your own
-driver custom resources and apply them to specific nodes, delete the default custom resource.
+To prevent the Helm chart from creating the default resource, specify the
+``--set driver.nvidiaDriverCRD.deployDefaultCR=false`` argument when you install or upgrade the Operator.
+Use this setting only if your user-defined resources select every GPU node that the Operator should manage,
+or if leaving some GPU nodes without an Operator-managed driver is intentional.
 
 .. note::
 
-   After you delete the default custom resource, your custom resources might not reconcile
-   automatically due to a known issue. Refer to the :ref:`v26.3.0 known issues <v26.3.0-known-issues>`
-   for the workaround.
+   A user-defined resource without a node selector matches all GPU nodes.
+   The resource takes precedence over the default resource and conflicts with any other resource
+   that selects one of the same nodes.
 
 
 Feature Compatibility
@@ -140,6 +153,116 @@ Custom Driver Parameters
   Each NVIDIA driver custom resource can specify custom kernel module parameters by using a ConfigMap.
   For more information, refer to :doc:`Customizing NVIDIA GPU Driver Parameters during Installation <custom-driver-params>`.
 
+
+.. _migrate-clusterpolicy-to-nvidiadriver:
+
+***********************************************
+Migrating from Cluster Policy Driver Management
+***********************************************
+
+You can migrate an existing Helm installation to NVIDIA driver custom resource management through
+the controlled driver upgrade flow.
+During the migration, the Operator assigns each GPU node to an NVIDIA driver custom resource and uses the
+driver upgrade controller to replace the previous cluster policy managed driver pod on each node.
+
+When you migrate from a GPU Operator release earlier than v26.7.0, perform two Helm upgrades.
+First, upgrade to v26.7.0 while retaining cluster policy driver management.
+Then, upgrade the same release again to enable NVIDIA driver custom resource management.
+This sequence starts the controller that supports controlled migration before changing driver ownership.
+Do not upgrade from an earlier release and enable NVIDIA driver custom resource management in the same
+Helm operation because the old controller can remove the existing driver pods before the new controller
+can take ownership.
+
+Before you begin, verify the following requirements:
+
+* The Helm values under ``driver`` represent the driver configuration that you want the chart-created
+  default NVIDIA driver custom resource to use.
+  The Operator does not copy changes made directly to the ``spec.driver`` field of the cluster policy
+  custom resource into the new resource.
+* Any existing non-default NVIDIA driver custom resources have non-overlapping node selectors.
+  These resources become active when you enable NVIDIA driver custom resource management.
+* ``driver.upgradePolicy.autoUpgrade`` is ``true`` so that the upgrade controller can perform the
+  controlled replacement of the previous driver pods.
+  Nodes with the ``nvidia.com/gpu-driver-upgrade.skip=true`` label are not migrated until you remove
+  the label.
+* Your workloads can tolerate the disruption configured by the driver upgrade policy.
+  For more information, refer to :ref:`gpu-driver-upgrades`.
+
+#. Identify the Helm release name:
+
+   .. code-block:: console
+
+      $ helm list -n gpu-operator
+
+#. If your current GPU Operator release is earlier than v26.7.0, upgrade to the target release while
+   retaining cluster policy driver management:
+
+   .. code-block:: console
+
+      $ helm upgrade <release-name> nvidia/gpu-operator \
+          -n gpu-operator \
+          --version=${version} \
+          --reuse-values \
+          --disable-openapi-validation \
+          --set operator.upgradeCRD=true \
+          --set driver.nvidiaDriverCRD.enabled=false \
+          --set driver.nvidiaDriverCRD.deployDefaultCR=false \
+          --wait
+
+   This operation updates the custom resource definitions, starts the controller that supports
+   controlled migration, and leaves the existing cluster policy managed driver pods in place.
+   For more information about manually updating the custom resource definitions instead of using
+   the Helm hook, refer to :doc:`Upgrading the GPU Operator <upgrade>`.
+
+   Wait for the cluster policy custom resource to return to the ``ready`` state.
+
+#. Upgrade the Helm release and enable NVIDIA driver custom resource management:
+
+   .. code-block:: console
+
+      $ helm upgrade <release-name> nvidia/gpu-operator \
+          -n gpu-operator \
+          --version=${version} \
+          --reuse-values \
+          --set driver.nvidiaDriverCRD.enabled=true \
+          --set driver.nvidiaDriverCRD.deployDefaultCR=true \
+          --set driver.upgradePolicy.autoUpgrade=true \
+          --wait
+
+   The chart sets ``spec.driver.useNvidiaDriverCRD`` to ``true`` in the cluster policy custom resource
+   and creates a default NVIDIA driver custom resource from the Helm driver values.
+   The cluster policy custom resource continues to manage the other GPU Operator operands.
+   If the controlled rollout can exceed the default Helm timeout, specify an appropriate duration
+   with the ``--timeout`` option.
+
+#. Confirm that exactly one default resource exists:
+
+   .. code-block:: console
+
+      $ kubectl get nvidiadrivers
+
+   The output includes ``true`` in the ``DEFAULT`` column for the chart-created resource.
+   The resource can report ``notReady`` while the migration is in progress.
+
+#. Monitor node ownership and the controlled upgrade:
+
+   .. code-block:: console
+
+      $ kubectl get nodes -l nvidia.com/gpu.present=true \
+          -L nvidia.com/gpu-operator.driver.owner \
+          -L nvidia.com/gpu-driver-upgrade-state
+
+   The migration is complete when each managed node has an NVIDIA driver owner and reports
+   ``upgrade-done``, and the NVIDIA driver and cluster policy custom resources report ``ready``.
+
+After the migration, you can create additional NVIDIA driver custom resources with node selectors.
+Those resources take ownership of their matching nodes, while the default resource remains the
+fallback for the other GPU nodes.
+If you do not want the upgrade controller to manage later driver updates automatically, set
+``driver.upgradePolicy.autoUpgrade`` to ``false`` in the Helm values for the chart-created default
+resource after the migration completes.
+For a user-created resource, set ``spec.upgradePolicy.autoUpgrade`` to ``false``.
+
 ***************************************
 About the NVIDIA Driver Custom Resource
 ***************************************
@@ -168,6 +291,12 @@ The following table describes some of the fields in the custom resource.
    * - ``annotations``
      - Specifies a map of key and value pairs to add as custom annotations to the driver pod.
      - None
+
+   * - ``default``
+     - Specifies whether the resource is the fallback driver configuration for GPU nodes that do not
+       match a non-default resource.
+       Only one resource can be the default, and a default resource cannot specify ``nodeSelector``.
+     - ``false``
 
    * - ``driverType``
      - Specifies one of the following:
@@ -218,8 +347,16 @@ The following table describes some of the fields in the custom resource.
    * - ``nodeSelector``
      - Specifies one or more node labels to match.
        The driver container is scheduled to nodes that match all the labels.
+       Do not specify the Operator-managed ``nvidia.com/gpu-operator.driver.owner`` label.
      - None.
-       When you do not specify this field, the driver custom resource selects all nodes.
+       When you do not specify this field on a non-default resource, the resource selects all GPU nodes.
+
+   * - ``upgradePolicy``
+     - Specifies how the upgrade controller upgrades the nodes managed by this resource.
+       Each NVIDIA driver custom resource can have a different policy.
+       Refer to :ref:`gpu-driver-upgrades`.
+     - Automatic upgrades are enabled, with one node upgraded at a time and a maximum of 25 percent
+       of the managed nodes unavailable.
 
    * - ``priorityClassName``
      - Specifies the priority class for the driver pod.
@@ -294,6 +431,8 @@ Perform the following steps to install the GPU Operator and use the NVIDIA drive
 
      By default, Helm configures a ``default`` NVIDIA driver custom resource during installation.
      To prevent configuring the default custom resource, also specify ``--set driver.nvidiaDriverCRD.deployDefaultCR=false``.
+     You do not need to disable or delete the default resource before you add non-default resources
+     with node selectors.
 
 #. Apply NVIDIA driver custom resources manifests to install the NVIDIA GPU driver version, type, and so on for your nodes.
    Refer to the sample manifests.
@@ -423,33 +562,10 @@ Precompiled Driver Container on Some Nodes
 Upgrading the NVIDIA GPU Driver
 *******************************
 
-You can upgrade the driver version by editing or patching the NVIDIA driver custom resource.
-
-When you update the custom resource, the Operator performs a rolling update of the pods in the affected daemon set.
-
-#. Update the ``driver.version`` field in the driver custom resource:
-
-   .. code-block:: console
-
-      $ kubectl patch nvidiadriver/demo-silver --type='json' \
-          -p='[{"op": "replace", "path": "/spec/version", "value": "525.125.06"}]'
-
-#. Optional: Monitor the progress:
-
-   .. code-block:: console
-
-      $ kubectl get pods -n gpu-operator -l app.kubernetes.io/component=nvidia-driver
-
-   *Example Output*
-
-   .. code-block:: output
-
-      NAME                                             READY   STATUS        RESTARTS   AGE
-      nvidia-gpu-driver-ubuntu24.04-788484b9bb-6zhd9   1/1     Running       0          5m1s
-      nvidia-gpu-driver-ubuntu22.04-8896c4bf7-7s68q    1/1     Terminating   0          37m
-      nvidia-gpu-driver-ubuntu22.04-8896c4bf7-jm74l    1/1     Running       0          37m
-
-Eventually, the Operator replaces the pods that used the previous driver version with pods that use the updated driver version.
+To upgrade a driver managed by an NVIDIA driver custom resource, update the ``spec.version`` field.
+The upgrade controller applies the resource's ``spec.upgradePolicy`` to the nodes that it manages.
+For the upgrade procedure, configuration options, and monitoring guidance, refer to
+:ref:`gpu-driver-upgrades`.
 
 
 .. _nvd-troubleshooting:
@@ -470,11 +586,15 @@ If the driver daemon sets and pods are not running as you expect, perform the fo
 
    .. code-block:: output
 
-      NAME           STATUS     AGE
-      default        notReady   2023-10-13T14:03:24Z
-      demo-precomp   notReady   2023-10-13T14:21:55Z
+      NAME           STATUS     DEFAULT   AGE
+      default        ready      true      20m
+      demo-precomp   notReady   false     2m
 
    It is normal for the status to report not ready shortly after modifying the resource.
+   If more than one row reports ``true`` in the ``DEFAULT`` column, update or delete the extra
+   default resource.
+   Duplicate default resources report ``notReady`` with a ``ReconcileFailed`` condition, and the
+   Operator retains the existing node ownership until the conflict is resolved.
 
 #. If the status is not ready, describe the resource:
 

--- a/gpu-operator/gpu-driver-configuration.rst
+++ b/gpu-operator/gpu-driver-configuration.rst
@@ -112,13 +112,16 @@ Delete or update the extra default resource to resume reconciliation.
 
 To prevent the Helm chart from creating the default resource, specify the
 ``--set driver.nvidiaDriverCRD.deployDefaultCR=false`` argument when you install or upgrade the Operator.
-Use this setting only if your user-defined resources select every GPU node that the Operator should manage,
-or if leaving some GPU nodes without an Operator-managed driver is intentional.
+This setting can help you meet any of the following goals:
+
+- You will add user-defined resources that select every GPU node that the Operator should manage.
+- You will add a default resource--by specifying ``spec.default: true``--as a fallback.
+- Or, leaving some GPU nodes without an Operator-managed driver is intentional.
 
 .. note::
 
-   A user-defined resource without a node selector matches all GPU nodes.
-   The resource takes precedence over the default resource and conflicts with any other resource
+   A user-defined ``NVIDIADriver`` custom resource without a node selector matches all GPU nodes.
+   Such a resource takes precedence over the default custom resource and conflicts with any other
    that selects one of the same nodes.
 
 
@@ -165,9 +168,14 @@ the controlled driver upgrade flow.
 During the migration, the Operator assigns each GPU node to an NVIDIA driver custom resource and uses the
 driver upgrade controller to replace the previous cluster policy managed driver pod on each node.
 
-When you migrate from a GPU Operator release earlier than v26.7.0, perform two Helm upgrades.
-First, upgrade to v26.7.0 while retaining cluster policy driver management.
-Then, upgrade the same release again to enable NVIDIA driver custom resource management.
+When you migrate from a GPU Operator release earlier than v26.7.0, perform two Helm upgrades:
+
+* First, upgrade to v26.7.0 while retaining cluster policy driver management.
+* Afterward, upgrade to the same release again.
+  This time, enable NVIDIA driver custom resource management.
+
+  The exact commands and arguments are shown in the following procedure.
+
 This sequence starts the controller that supports controlled migration before changing driver ownership.
 Do not upgrade from an earlier release and enable NVIDIA driver custom resource management in the same
 Helm operation because the old controller can remove the existing driver pods before the new controller
@@ -194,7 +202,8 @@ Before you begin, verify the following requirements:
 
       $ helm list -n gpu-operator
 
-#. If your current GPU Operator release is earlier than v26.7.0, upgrade to the target release while
+#. If your current GPU Operator release is earlier than v26.7.0 and the cluster does not already use
+   ``NVIDIADriver`` resources, upgrade to the target release while
    retaining cluster policy driver management:
 
    .. code-block:: console

--- a/gpu-operator/gpu-driver-upgrades.rst
+++ b/gpu-operator/gpu-driver-upgrades.rst
@@ -53,122 +53,227 @@ Upgrades with the Upgrade Controller
 
 NVIDIA recommends upgrading by using the upgrade controller and the controller is enabled by default in the GPU Operator.
 The controller automates the upgrade process and generates metrics and events so that you can monitor the upgrade process.
+It supports both cluster policy driver management and NVIDIA driver custom resource management.
+The upgrade controller does not require a cluster policy custom resource when NVIDIA driver custom
+resources manage the driver.
 
-.. rubric:: Procedure
+Quick Reference
+===============
 
-1. Upgrade the driver by changing the ``driver.version`` value in the cluster policy:
+.. list-table::
+   :header-rows: 1
 
-   .. code-block:: console
+   * - Driver management method
+     - Resource to update
+     - Driver version field
+     - Upgrade policy field
+   * - NVIDIA driver custom resource
+     - ``NVIDIADriver/<name>``
+     - ``spec.version``
+     - ``spec.upgradePolicy``
+   * - Cluster policy custom resource
+     - ``ClusterPolicy/cluster-policy``
+     - ``spec.driver.version``
+     - ``spec.driver.upgradePolicy``
 
-      $ kubectl patch clusterpolicies.nvidia.com/cluster-policy \
-          --type='json' \
-          -p='[{"op": "replace", "path": "/spec/driver/version", "value":"580.95.05"}]'
+Procedure
+=========
 
+Select the driver management method that you use.
 
-   If you are using Openshift, you must update the ``driver.version``, ``driver.repository`` and ``driver.image`` values in the cluster policy.
+.. tab-set::
+   :sync-group: driver-management-mode
 
-   .. code-block:: console
+   .. tab-item:: NVIDIA Driver Custom Resource
+      :sync: nvidia-driver-cr
 
-      $ kubectl patch clusterpolicies.nvidia.com/cluster-policy \
-          --type='json' \
-          -p='[{"op": "replace", "path": "/spec/driver/version", "value":"580.95.05"},{"op": "replace", "path": "/spec/driver/repository", "value":"nvcr.io/nvidia"},{"op": "replace", "path": "/spec/driver/image", "value":"driver"}]'
+      #. Upgrade the driver by changing ``spec.version`` in the NVIDIA driver custom resource that
+         manages the target nodes:
 
-2. (Optional) For each node, monitor the upgrade status:
+         .. code-block:: console
 
-   .. code-block:: console
+            $ kubectl patch nvidiadrivers.nvidia.com/<resource-name> \
+                --type='json' \
+                -p='[{"op": "replace", "path": "/spec/version", "value":"580.95.05"}]'
 
-      $ kubectl get node -l nvidia.com/gpu.present \
-         -ojsonpath='{range .items[*]}{.metadata.name}{"\t"}{.metadata.labels.nvidia\.com/gpu-driver-upgrade-state}{"\n"}{end}'
+      #. Optional: For each node, monitor the upgrade status:
 
-   *Example Output*
+         .. code-block:: console
 
-   .. code-block:: output
+            $ kubectl get node -l nvidia.com/gpu.present \
+               -ojsonpath='{range .items[*]}{.metadata.name}{"\t"}{.metadata.labels.nvidia\.com/gpu-driver-upgrade-state}{"\n"}{end}'
 
-      k8s-node-1 upgrade-required
-      k8s-node-2 upgrade-required
-      k8s-node-3 upgrade-required
+         *Example Output*
 
-   You can periodically poll the upgrade status by running the preceding command.
-   The GPU driver upgrade is complete when the output shows ``upgrade-done``:
+         .. code-block:: output
 
-   .. code-block:: output
+            k8s-node-1 upgrade-required
+            k8s-node-2 upgrade-required
+            k8s-node-3 upgrade-required
 
-      k8s-node-1 upgrade-done
-      k8s-node-2 upgrade-done
-      k8s-node-3 upgrade-done
+         You can periodically poll the upgrade status by running the preceding command.
+         The GPU driver upgrade is complete when the output shows ``upgrade-done``:
+
+         .. code-block:: output
+
+            k8s-node-1 upgrade-done
+            k8s-node-2 upgrade-done
+            k8s-node-3 upgrade-done
+
+   .. tab-item:: Cluster Policy Custom Resource
+      :sync: cluster-policy
+
+      #. Upgrade the driver by changing ``spec.driver.version`` in the cluster policy custom resource:
+
+         .. code-block:: console
+
+            $ kubectl patch clusterpolicies.nvidia.com/cluster-policy \
+                --type='json' \
+                -p='[{"op": "replace", "path": "/spec/driver/version", "value":"580.95.05"}]'
+
+         If you are using OpenShift, you must update the ``spec.driver.version``,
+         ``spec.driver.repository``, and ``spec.driver.image`` values:
+
+         .. code-block:: console
+
+            $ kubectl patch clusterpolicies.nvidia.com/cluster-policy \
+                --type='json' \
+                -p='[{"op": "replace", "path": "/spec/driver/version", "value":"580.95.05"},{"op": "replace", "path": "/spec/driver/repository", "value":"nvcr.io/nvidia"},{"op": "replace", "path": "/spec/driver/image", "value":"driver"}]'
+
+      #. Optional: For each node, monitor the upgrade status:
+
+         .. code-block:: console
+
+            $ kubectl get node -l nvidia.com/gpu.present \
+               -ojsonpath='{range .items[*]}{.metadata.name}{"\t"}{.metadata.labels.nvidia\.com/gpu-driver-upgrade-state}{"\n"}{end}'
+
+         *Example Output*
+
+         .. code-block:: output
+
+            k8s-node-1 upgrade-required
+            k8s-node-2 upgrade-required
+            k8s-node-3 upgrade-required
+
+         You can periodically poll the upgrade status by running the preceding command.
+         The GPU driver upgrade is complete when the output shows ``upgrade-done``:
+
+         .. code-block:: output
+
+            k8s-node-1 upgrade-done
+            k8s-node-2 upgrade-done
+            k8s-node-3 upgrade-done
 
 
 Configuration Options
 =====================
 
-You can set the following fields in the cluster policy to configure the upgrade controller:
+.. tab-set::
+   :sync-group: driver-management-mode
 
-.. code-block:: yaml
+   .. tab-item:: NVIDIA Driver Custom Resource
+      :sync: nvidia-driver-cr
 
-   driver:
+      Configure ``spec.upgradePolicy`` on each NVIDIA driver custom resource.
+      The policy applies only to nodes owned by that resource, so different node pools can use
+      different parallelism, availability, workload eviction, and drain settings:
 
-     upgradePolicy:
-       # autoUpgrade (default=true): Switch which enables / disables the driver upgrade controller.
-       # If set to false all other options are ignored.
-       autoUpgrade: true
-       # maxParallelUpgrades (default=1): Number of nodes that can be upgraded in parallel. 0 means infinite.
-       maxParallelUpgrades: 1
-       # maximum number of nodes with the driver installed, that can be unavailable during
-       # the upgrade. Value can be an absolute number (ex: 5) or
-       # a percentage of total nodes at the start of upgrade (ex:
-       # 10%). Absolute number is calculated from percentage by rounding
-       # up. By default, a fixed value of 25% is used.'
-       maxUnavailable: 25%
-       # waitForCompletion: Options for the 'wait-for-completion' state, which will wait for a user-defined group of pods
-       # to complete before upgrading the driver on a node.
-       waitForCompletion:
-         # timeoutSeconds (default=0): The length of time to wait before giving up. 0 means infinite.
-         timeoutSeconds: 0
-         # podSelector (default=""): The label selector defining the group of pods to wait for completion of. "" means to wait on none.
-         podSelector: ""
+      .. code-block:: yaml
 
-       # gpuPodDeletion: Options for the 'pod-deletion' state, which will evict all pods on the node allocated a GPU.
-       gpuPodDeletion:
-         # force (default=false): Delete pods even if they are not managed by a controller (for example ReplicationController, ReplicaSet,
-         # Job, DaemonSet or StatefulSet).
-         force: false
-         # timeoutSeconds (default=300): The length of time to wait before giving up. 0 means infinite. When the timeout is met,
-         # the GPU  pod(s) will be forcefully deleted.
-         timeoutSeconds: 300
-         # deleteEmptyDir (default=false): Delete pods even if they are using emptyDir volumes (local data will be deleted).
-         deleteEmptyDir: false
+         apiVersion: nvidia.com/v1alpha1
+         kind: NVIDIADriver
+         metadata:
+           name: example
+         spec:
+           version: 580.95.05
+           nodeSelector:
+             driver.config: example
+           upgradePolicy:
+             autoUpgrade: true
+             maxParallelUpgrades: 1
+             maxUnavailable: 25%
+             waitForCompletion:
+               timeoutSeconds: 0
+               podSelector: ""
+             podDeletion:
+               force: false
+               timeoutSeconds: 300
+               deleteEmptyDir: false
+             drain:
+               enable: false
+               force: false
+               podSelector: ""
+               timeoutSeconds: 300
+               deleteEmptyDir: false
 
-       # drain: Options for the 'drain' state, which invokes 'kubectl drain' on the node.
-       # Unlike 'gpuPodDeletion', which targets only GPU-allocated pods, drain evicts all pods on the node.
-       # This should only be enabled as a fallback when 'gpuPodDeletion' cannot remove all GPU-using pods on its own.
-       drain:
-         # enable (default=false): Set to true to allow node drain as a fallback when
-         # 'gpuPodDeletion' cannot evict all GPU pods. By default, drain evicts all pods
-         # on the node. Use podSelector to limit which pods are evicted.
-         enable: false
-         # force (default=false): Delete pods even if they are not managed by a controller
-         # (for example, ReplicationController, ReplicaSet, Job, DaemonSet, or StatefulSet).
-         # Applies to all pods on the node, not just GPU pods.
-         force: false
-         # podSelector (default=""): Label selector to restrict which pods are evicted
-         # during drain. An empty string means all pods on the node are evicted.
-         podSelector: ""
-         # timeoutSeconds (default=300): The length of time to wait before giving up.
-         # 0 means infinite. When the timeout is reached, the drain attempt is abandoned.
-         timeoutSeconds: 300
-         # deleteEmptyDir (default=false): Allow eviction of pods that use emptyDir volumes.
-         # Enabling this results in permanent loss of any data stored in those volumes.
-         deleteEmptyDir: false
+      If ``spec.upgradePolicy`` is omitted, the Operator enables automatic upgrades with
+      ``maxParallelUpgrades: 1``, ``maxUnavailable: 25%``, and the defaults shown in the preceding
+      example.
+      The ``maxParallelUpgrades`` and ``maxUnavailable`` limits are evaluated separately for the
+      nodes owned by each resource.
+
+   .. tab-item:: Cluster Policy Custom Resource
+      :sync: cluster-policy
+
+      Configure ``spec.driver.upgradePolicy`` in the cluster policy custom resource.
+      One policy applies to all driver nodes:
+
+      .. code-block:: yaml
+
+         spec:
+           driver:
+             upgradePolicy:
+               autoUpgrade: true
+               maxParallelUpgrades: 1
+               maxUnavailable: 25%
+               waitForCompletion:
+                 timeoutSeconds: 0
+                 podSelector: ""
+               gpuPodDeletion:
+                 force: false
+                 timeoutSeconds: 300
+                 deleteEmptyDir: false
+               drain:
+                 enable: false
+                 force: false
+                 podSelector: ""
+                 timeoutSeconds: 300
+                 deleteEmptyDir: false
+
+The policy fields have the following effects:
+
+``autoUpgrade``
+  Enables or disables the upgrade controller for the applicable nodes.
+  When set to ``false``, the other policy fields are ignored.
+``maxParallelUpgrades``
+  Sets the number of nodes that can be upgraded in parallel.
+  A value of ``0`` means that there is no limit.
+``maxUnavailable``
+  Sets the maximum number or percentage of applicable nodes that can be unavailable during an upgrade.
+``waitForCompletion``
+  Selects pods or jobs that must finish before the driver is upgraded on a node and sets how long to wait.
+  A ``timeoutSeconds`` value of ``0`` waits indefinitely.
+``gpuPodDeletion`` or ``podDeletion``
+  Controls eviction of pods that have allocated GPUs.
+  ``gpuPodDeletion`` is the field name in the cluster policy and ``podDeletion`` is the field name
+  in an NVIDIA driver custom resource.
+``drain``
+  Configures node drain as a fallback when GPU pod deletion cannot remove the GPU workloads.
+  By default, drain is disabled.
 
 .. warning::
 
-   ``driver.upgradePolicy.drain.enable`` is a cluster-wide policy setting.
-   When set to ``true``, the upgrade controller drains each node before upgrading the driver on that node.
+   ``spec.driver.upgradePolicy.drain.enable`` in the cluster policy applies to all nodes managed by
+   that driver configuration.
+   ``spec.upgradePolicy.drain.enable`` in an NVIDIA driver custom resource applies to the nodes owned
+   by that resource.
+   When set to ``true``, the upgrade controller can drain each applicable node before upgrading the driver on that node.
    Draining a node evicts all pods from that node, including workloads unrelated to the GPU driver.
-   This is a disruptive operation that interrupts running GPU and non-GPU workloads on every node the upgrade controller processes.
+   This is a disruptive operation that interrupts running GPU and non-GPU workloads on every node the policy processes.
 
-   Enable ``drain`` only when ``gpuPodDeletion`` is insufficient to remove all GPU-using pods on its own.
-   Adjust the ``gpuPodDeletion`` settings first and use ``drain`` only if those settings do not work.
+   Enable ``drain`` only when ``gpuPodDeletion`` in the cluster policy, or ``podDeletion`` in an
+   NVIDIA driver custom resource, is insufficient to remove all GPU-using pods on its own.
+   Adjust the pod deletion settings first and use ``drain`` only if those settings do not work.
    If you must enable ``drain``, use ``podSelector`` to limit which pods are evicted.
 
 If you specify a value for ``maxUnavailable`` and also specify ``maxParallelUpgrades``,
@@ -176,10 +281,10 @@ the ``maxUnavailable`` value applies an additional constraint on the value of
 ``maxParallelUpgrades`` to ensure that the number of parallel upgrades does not
 cause more than the intended number of nodes to become unavailable during the upgrade.
 For example, if you specify ``maxUnavailable=100%`` and ``maxParallelUpgrades=1``,
-one node is upgraded at a time .
+one node is upgraded at a time.
 
-The ``maxUnavailable`` value also applies to the currently unavailable nodes in the cluster.
-If you cordoned nodes in the cluster and the ``maxUnavailable`` value is already met by the number of cordoned nodes,
+The ``maxUnavailable`` value also applies to currently unavailable nodes in the applicable node set.
+If the number of cordoned nodes already meets the ``maxUnavailable`` value,
 then the upgrade does not progress.
 
 
@@ -195,11 +300,11 @@ The set of possible states are:
 * ``cordon-required``: Node will be marked Unschedulable in preparation for the driver upgrade.
 * ``wait-for-jobs-required``: Node will wait on the completion of a group of pods/jobs before proceeding.
 * ``pod-deletion-required``: Pods allocated with GPUs are deleted from the node. If pod deletion fails, the node state is set to ``drain-required``
-  if drain is enabled in ClusterPolicy.
+  if drain is enabled in the applicable upgrade policy.
 * ``drain-required``: Node is drained using ``kubectl drain``, which evicts all pods on the
   node.
-  This state is only reached if ``gpuPodDeletion`` fails to remove all
-  GPU-using pods and ``drain.enable`` is set to ``true`` in the cluster policy.
+  This state is only reached if pod deletion fails to remove all
+  GPU-using pods and ``drain.enable`` is set to ``true`` in the applicable upgrade policy.
   This state is skipped if all GPU pods are successfully deleted from the node.
 * ``pod-restart-required``: The NVIDIA driver pod running on the node will be restarted and upgraded to the new version.
 * ``validation-required``: Validation of the new driver deployed on the node is required before proceeding. The GPU Operator
@@ -216,10 +321,12 @@ The complete state machine is depicted in the diagram below.
 Pausing Driver Upgrades
 =======================
 
-To pause the automatic driver upgrade process in the cluster, toggle ``driver.upgradePolicy.autoUpgrade`` flag
-in the cluster policy.
-The entire state machine pauses and effectively disables any pending nodes from being upgraded.
-You can toggle the flag to ``true`` again to re-enable the upgrade controller and resume any pending upgrades.
+With cluster policy driver management, set ``spec.driver.upgradePolicy.autoUpgrade`` to ``false``
+to pause automatic upgrades for all driver nodes.
+With NVIDIA driver custom resource management, set ``spec.upgradePolicy.autoUpgrade`` to ``false``
+on a resource to pause automatic upgrades only for the nodes that it owns.
+The Operator removes the upgrade-state labels from those nodes.
+Set the field to ``true`` to re-enable automatic upgrades.
 
 Skipping Driver Upgrades
 ========================
@@ -230,6 +337,9 @@ Metrics and Events
 ==================
 
 The GPU Operator generates the following metrics during the upgrade process which can be scraped by Prometheus.
+When NVIDIA driver custom resources manage the driver, the node upgrade metrics are aggregated across
+all resources, and ``gpu_operator_auto_upgrade_enabled`` is ``1`` when at least one resource enables
+automatic upgrades.
 
 * ``gpu_operator_auto_upgrade_enabled``: 1 if driver auto upgrade is enabled; 0 if not.
 * ``gpu_operator_nodes_upgrades_in_progress``: Total number of nodes in which a driver pod is being upgraded on.
@@ -311,19 +421,50 @@ This method still automates the core driver upgrade process, but lacks the obser
 controls such as pausing/skipping upgrades.
 In addition, no new features will be added to the ``k8s-driver-manager`` moving forward in favor of the upgrade controller.
 
-.. rubric:: Procedure
+Procedure
+=========
 
-1. Upgrade the driver by changing ``driver.version`` value in ClusterPolicy:
+.. tab-set::
+   :sync-group: driver-management-mode
 
-   .. code-block:: console
+   .. tab-item:: NVIDIA Driver Custom Resource
+      :sync: nvidia-driver-cr
 
-      $ kubectl patch clusterpolicies.nvidia.com/cluster-policy --type='json' -p='[{"op": "replace", "path": "/spec/driver/version", "value":"580.95.05"},{"op": "replace", "path": "/spec/driver/repository", "value":"nvcr.io/nvidia"},{"op": "replace", "path": "/spec/driver/image", "value":"driver"}]'
+      #. Upgrade the driver by changing ``spec.version`` in the NVIDIA driver custom resource that
+         manages the target nodes:
 
-2. (Optional) To monitor the status of the upgrade, watch the deployment of the new driver pod on GPU worker nodes:
+         .. code-block:: console
 
-   .. code-block:: console
+            $ kubectl patch nvidiadrivers.nvidia.com/<resource-name> \
+                --type='json' \
+                -p='[{"op": "replace", "path": "/spec/version", "value":"580.95.05"}]'
 
-      $ kubectl get pods -n gpu-operator -lapp=nvidia-driver-daemonset -w
+      #. Optional: Monitor the upgrade by watching the deployment of the new driver pods on GPU
+         worker nodes:
+
+         .. code-block:: console
+
+            $ kubectl get pods -n gpu-operator \
+                -l app.kubernetes.io/component=nvidia-driver -w
+
+   .. tab-item:: Cluster Policy Custom Resource
+      :sync: cluster-policy
+
+      #. Upgrade the driver by changing the driver version, repository, and image in the cluster
+         policy custom resource:
+
+         .. code-block:: console
+
+            $ kubectl patch clusterpolicies.nvidia.com/cluster-policy \
+                --type='json' \
+                -p='[{"op": "replace", "path": "/spec/driver/version", "value":"580.95.05"},{"op": "replace", "path": "/spec/driver/repository", "value":"nvcr.io/nvidia"},{"op": "replace", "path": "/spec/driver/image", "value":"driver"}]'
+
+      #. Optional: Monitor the upgrade by watching the deployment of the new driver pods on GPU
+         worker nodes:
+
+         .. code-block:: console
+
+            $ kubectl get pods -n gpu-operator -lapp=nvidia-driver-daemonset -w
 
 Configuration Options
 =====================
@@ -331,23 +472,59 @@ Configuration Options
 The following configuration options are available for ``k8s-driver-manager``. The options allow users to control the
 GPU pod eviction and node drain behavior.
 
-.. code-block:: yaml
+.. tab-set::
+   :sync-group: driver-management-mode
 
-   driver:
-     manager:
-       env:
-       - name: ENABLE_GPU_POD_EVICTION
-         value: "true"
-       - name: ENABLE_AUTO_DRAIN
-         value: "true"
-       - name: DRAIN_USE_FORCE
-         value: "false"
-       - name: DRAIN_POD_SELECTOR_LABEL
-         value: ""
-       - name: DRAIN_TIMEOUT_SECONDS
-         value: "0s"
-       - name: DRAIN_DELETE_EMPTYDIR_DATA
-         value: "false"
+   .. tab-item:: NVIDIA Driver Custom Resource
+      :sync: nvidia-driver-cr
+
+      Configure the options under ``spec.manager.env`` in each NVIDIA driver custom resource:
+
+      .. code-block:: yaml
+
+         apiVersion: nvidia.com/v1alpha1
+         kind: NVIDIADriver
+         metadata:
+           name: example
+         spec:
+           manager:
+             env:
+             - name: ENABLE_GPU_POD_EVICTION
+               value: "true"
+             - name: ENABLE_AUTO_DRAIN
+               value: "true"
+             - name: DRAIN_USE_FORCE
+               value: "false"
+             - name: DRAIN_POD_SELECTOR_LABEL
+               value: ""
+             - name: DRAIN_TIMEOUT_SECONDS
+               value: "0s"
+             - name: DRAIN_DELETE_EMPTYDIR_DATA
+               value: "false"
+
+   .. tab-item:: Cluster Policy Custom Resource
+      :sync: cluster-policy
+
+      Configure the options under ``spec.driver.manager.env`` in the cluster policy custom resource:
+
+      .. code-block:: yaml
+
+         spec:
+           driver:
+             manager:
+               env:
+               - name: ENABLE_GPU_POD_EVICTION
+                 value: "true"
+               - name: ENABLE_AUTO_DRAIN
+                 value: "true"
+               - name: DRAIN_USE_FORCE
+                 value: "false"
+               - name: DRAIN_POD_SELECTOR_LABEL
+                 value: ""
+               - name: DRAIN_TIMEOUT_SECONDS
+                 value: "0s"
+               - name: DRAIN_DELETE_EMPTYDIR_DATA
+                 value: "false"
 
 * The ``ENABLE_GPU_POD_EVICTION`` environment variable enables ``k8s-driver-manager`` to attempt evicting only GPU pods from the node before attempting a node drain. Only if this fails and
   ``ENABLE_AUTO_DRAIN`` is enabled will the node ever be drained.
@@ -361,4 +538,3 @@ GPU pod eviction and node drain behavior.
    With ``OnDelete`` update strategy, a new driver pod with the updated spec will only get deployed on a node once the old driver pod is manually deleted.
    Thus, admins can control when to rollout spec updates to driver pods on any given node.
    For more information on DaemonSet update strategies, refer to the `Kubernetes documentation <https://kubernetes.io/docs/tasks/manage-daemon/update-daemon-set/#daemonset-update-strategy>`_.
-

--- a/repo.toml
+++ b/repo.toml
@@ -175,8 +175,8 @@ output_format = "linkcheck"
 docs_root = "${root}/gpu-operator"
 project = "gpu-operator"
 name = "NVIDIA GPU Operator"
-version = "26.3"  # Update repo_docs.projects.openshift.version to match latest patch version maj.min.patch
-source_substitutions = { minor_version = "26.3", version = "v26.3.3", recommended = "580.173.02", dra_version = "0.4.1", kata_version = "4.0.0" }
+version = "26.7"  # Update repo_docs.projects.openshift.version to match latest patch version maj.min.patch
+source_substitutions = { minor_version = "26.7", version = "v26.7.0", recommended = "580.173.02", dra_version = "0.4.1", kata_version = "4.0.0" }
 copyright_start = 2020
 sphinx_exclude_patterns = [
   "life-cycle-policy.rst",


### PR DESCRIPTION
Documents https://github.com/NVIDIA/cloud-native-team/issues/245

Review HTML:
- Updates for [mode](https://nvidia.github.io/cloud-native-docs/review/pr-459/gpu-operator/latest/gpu-driver-configuration.html#driver-management-modes) on the driver CRD.  The same page has the migration.
- Update to the [driver upgrade](https://nvidia.github.io/cloud-native-docs/review/pr-459/gpu-operator/latest/gpu-driver-upgrades.html#upgrades-with-the-upgrade-controller) page to move the upgrade procedure here.  I made a guess that with the enhancements, we'd want more visibility into the capabilities.  LMK if you prefer it back on the driver CRD page.