### PR TITLE
docs: Drivers, U26.04, rm centos

### DIFF
--- a/gpu-operator/install-gpu-operator-air-gapped.rst
+++ b/gpu-operator/install-gpu-operator-air-gapped.rst
@@ -25,11 +25,6 @@
 Install NVIDIA GPU Operator in Air-Gapped Environments
 ######################################################
 
-.. contents::
-   :local:
-   :backlinks: none
-   :depth: 2
-
 ******************************
 About Air-Gapped Installations
 ******************************
@@ -92,11 +87,11 @@ Before proceeding to the next sections, get the ``values.yaml`` file used for GP
 
 .. code-block:: console
 
-  $ curl -sO https://raw.githubusercontent.com/NVIDIA/gpu-operator/v1.7.0/deployments/gpu-operator/values.yaml
+  $ curl -sO https://raw.githubusercontent.com/NVIDIA/gpu-operator/${version}/deployments/gpu-operator/values.yaml
 
 .. note::
 
-   Replace ``v1.7.0`` in the above command with the version you want to use.
+   Replace ``${version}`` in the preceding command with the version you want to use.
 
 
 ********************
@@ -267,14 +262,6 @@ local mirror repository for their OS distribution and make the following package
        linux-image-${KERNEL_VERSION}
        linux-modules-${KERNEL_VERSION}
 
-    centos:
-       elfutils-libelf.x86_64
-       elfutils-libelf-devel.x86_64
-       kernel-headers-${KERNEL_VERSION}
-       kernel-devel-${KERNEL_VERSION}
-       kernel-core-${KERNEL_VERSION}
-       gcc-${GCC_VERSION}
-
     rhel/rhcos:
        kernel-headers-${KERNEL_VERSION}
        kernel-devel-${KERNEL_VERSION}
@@ -284,8 +271,6 @@ local mirror repository for their OS distribution and make the following package
 For example, for Ubuntu, these packages can be found at ``archive.ubuntu.com``.
 This is the mirror to be replicate locally for your cluster.
 You can use ``apt-mirror`` to mirror these packages to your local package repository server.
-
-For CentOS, ``reposync`` can be used to create the local mirror.
 
 After all the required packages are mirrored to the local repository, repo lists need to be created following
 distribution specific documentation. A ``ConfigMap`` containing the repo list file needs to be created in
@@ -310,30 +295,6 @@ An example of repo list is shown below for Ubuntu 24.04 (access to local package
    deb [arch=amd64] http://<local pkg repository>/ubuntu/mirror/archive.ubuntu.com/ubuntu noble main universe
    deb [arch=amd64] http://<local pkg repository>/ubuntu/mirror/archive.ubuntu.com/ubuntu noble-updates main universe
    deb [arch=amd64] http://<local pkg repository>/ubuntu/mirror/archive.ubuntu.com/ubuntu noble-security main universe
-
-An example of repo list is shown below for CentOS 8 (access to local package repository via HTTP):
-
-``custom-repo.repo``:
-
-.. code-block::
-
-   [baseos]
-   name=CentOS Linux $releasever - BaseOS
-   baseurl=http://<local pkg repository>/repos/centos/$releasever/$basearch/os/baseos/
-   gpgcheck=0
-   enabled=1
-
-   [appstream]
-   name=CentOS Linux $releasever - AppStream
-   baseurl=http://<local pkg repository>/repos/centos/$releasever/$basearch/os/appstream/
-   gpgcheck=0
-   enabled=1
-
-   [extras]
-   name=CentOS Linux $releasever - Extras
-   baseurl=http://<local pkg repository>/repos/centos/$releasever/$basearch/os/extras/
-   gpgcheck=0
-   enabled=1
 
 Create a ``ConfigMap`` object from the file:
 

--- a/gpu-operator/platform-support.rst
+++ b/gpu-operator/platform-support.rst
@@ -208,8 +208,8 @@ The following NVIDIA data center GPUs are supported on x86 based platforms:
     +-------------------------+------------------------+-------+
     | NVIDIA HGX GB300 NVL72  | NVIDIA Blackwell       |       |
     +-------------------------+------------------------+-------+
-    | NVIDIA DGX Station      | NVIDIA Blackwell       |       |  
-    +-------------------------+------------------------+-------+  
+    | NVIDIA DGX Station      | NVIDIA Blackwell       |       |
+    +-------------------------+------------------------+-------+
 
     .. note::
 
@@ -313,36 +313,46 @@ Bare Metal / Virtual Machines with GPU Passthrough and NVIDIA vGPU
       - Kubernetes |fn1|_
       - | Red Hat
         | OpenShift
-      - | VMware vSphere 
+      - | VMware vSphere
         | Kubernetes Service (VKS)
-      - | Rancher Kubernetes 
+      - | Rancher Kubernetes
         | Engine 2 |fn4|_
       - | K3s
       - | Mirantis k0s |fn4|_
       - | Canonical
-        | MicroK8s 
+        | MicroK8s
       - | Nutanix
         | NKP
 
-    * - Ubuntu 22.04 LTS |fn2|_
-      - 1.32---1.36 
+    * - Ubuntu 26.04 LTS
+      - 1.33---1.36
       -
-      - 1.32---1.36
-      - 1.32---1.36 
-      - 1.32---1.36
-      - 1.32---1.36 
+      -
+      - 1.33---1.36
+      - 1.33---1.36
+      - 1.33---1.36
       - 1.33---1.35
-      - 2.15 2.16 2.17
+      - 2.17
 
     * - Ubuntu 24.04 LTS
       - 1.32---1.36
       -
       -
-      - 1.32---1.36
-      - 1.32---1.36
-      - 1.32---1.36
+      - 1.33---1.36
+      - 1.33---1.36
+      - 1.33---1.36
       - 1.33---1.35
       - 2.17
+
+    * - Ubuntu 22.04 LTS |fn2|_
+      - 1.33---1.36
+      -
+      - 1.33---1.36
+      - 1.33---1.36
+      - 1.33---1.36
+      - 1.33---1.36
+      - 1.33---1.35
+      - 2.15 2.16 2.17
 
     * - Red Hat Core OS
       -
@@ -356,11 +366,11 @@ Bare Metal / Virtual Machines with GPU Passthrough and NVIDIA vGPU
 
     * - | Red Hat
         | Enterprise
-        | Linux 10.0, 10.1, 10.2 
-      - 1.32---1.36
+        | Linux 10.0, 10.1, 10.2
+      - 1.33---1.36
       -
       -
-      - 1.32---1.36
+      - 1.33---1.36
       -
       -
       -
@@ -369,10 +379,10 @@ Bare Metal / Virtual Machines with GPU Passthrough and NVIDIA vGPU
     * - | Red Hat
         | Enterprise
         | Linux 9.2, 9.4, 9.6, 9.7, 9.8 |fn3|_
-      - 1.32---1.36
+      - 1.33---1.36
       -
       -
-      - 1.32---1.36
+      - 1.33---1.36
       -
       -
       -
@@ -382,17 +392,17 @@ Bare Metal / Virtual Machines with GPU Passthrough and NVIDIA vGPU
         | Enterprise
         | Linux 8.8,
         | 8.10
-      - 1.32---1.36
+      - 1.33---1.36
       -
       -
-      - 1.32---1.36
+      - 1.33---1.36
       -
       -
       -
       - 2.15, 2.16, 2.17
 
     * - Rocky Linux 10.1
-      - 1.32---1.36
+      - 1.33---1.36
       -
       -
       -
@@ -402,7 +412,7 @@ Bare Metal / Virtual Machines with GPU Passthrough and NVIDIA vGPU
       -
 
     * - Rocky Linux 9.7
-      - 1.32---1.36
+      - 1.33---1.36
       -
       -
       -
@@ -412,7 +422,7 @@ Bare Metal / Virtual Machines with GPU Passthrough and NVIDIA vGPU
       -
 
     * - Rocky Linux 8.10
-      - 1.32---1.36
+      - 1.33---1.36
       -
       -
       -
@@ -464,18 +474,21 @@ Cloud Service Providers
     * - | Operating
         | System
       - | Amazon EKS
-        | Kubernetes 
+        | Kubernetes
       - | Google GKE
         | Kubernetes
 
-    * - Ubuntu 22.04 LTS
-      - 1.32---1.36
-      - 1.32---1.36
+    * - Ubuntu 26.04 LTS
+      - 1.33---1.36
+      - 1.33---1.36
 
     * - Ubuntu 24.04 LTS
-      - 1.32---1.36
-      - 1.32---1.36
+      - 1.33---1.36
+      - 1.33---1.36
 
+    * - Ubuntu 22.04 LTS
+      - 1.33---1.36
+      - 1.33---1.36
 
 .. _supported-precompiled-drivers:
 
@@ -486,18 +499,30 @@ Supported Precompiled Drivers
 The GPU Operator has been validated with the following precompiled drivers.
 See the :doc:`precompiled-drivers` page for more information about using precompiled drivers.
 
-+----------------------------+------------------------+----------------+---------------------+
-| Operating System           | Kernel Flavor          | Kernel Version | CUDA Driver Branch  |
-+============================+========================+================+=====================+
-| Ubuntu 22.04               | Generic, NVIDIA, Azure |  5.15          |  R535, R570, R580   |
-|                            | AWS, Oracle            |                |                     |
-+----------------------------+------------------------+----------------+---------------------+
-| Ubuntu 22.04               | Generic, NVIDIA, Azure |  6.8           |  R535, R570, R580   |
-|                            | AWS, Oracle            |                |                     |
-+----------------------------+------------------------+----------------+---------------------+
-| Ubuntu 24.04               | Generic, NVIDIA, Azure |  6.8           |  R570, R580         |
-|                            | AWS, Oracle            |                |                     |
-+----------------------------+------------------------+----------------+---------------------+
+.. list-table::
+    :header-rows: 1
+    :stub-columns: 1
+
+    * - | Operating
+        | System
+      - | Kernel Flavor
+      - | Kernel Version
+      - CUDA Driver Branch
+
+    * - Ubuntu 26.04
+      - Generic, NVIDIA, Azure, Azure-FDE, AWS, Oracle
+      - 7.0
+      - R595
+
+    * - Ubuntu 24.04
+      - Generic, NVIDIA, Azure, Azure-FDE, AWS, Oracle
+      - 6.8
+      - R580, R595
+
+    * - Ubuntu 22.04
+      - Generic, NVIDIA, Azure, AWS, Oracle
+      - 5.15, 6.8
+      - R580, R595
 
 ********************************
 Partner Validated Configurations
@@ -534,11 +559,13 @@ Supported Container Runtimes
 The GPU Operator has been validated for the following container runtimes:
 
 +----------------------------+------------------------+----------------+
-| Operating System           | Containerd 1.7 - 2.3   | CRI-O          |
+| Operating System           | Containerd 1.8 - 2.3   | CRI-O          |
 +============================+========================+================+
-| Ubuntu 22.04 LTS           | Yes                    | Yes            |
+| Ubuntu 26.04 LTS           | Yes                    | --             |
 +----------------------------+------------------------+----------------+
 | Ubuntu 24.04 LTS           | Yes                    | Yes            |
++----------------------------+------------------------+----------------+
+| Ubuntu 22.04 LTS           | Yes                    | Yes            |
 +----------------------------+------------------------+----------------+
 | Red Hat Core OS (RHCOS)    | No                     | Yes            |
 +----------------------------+------------------------+----------------+
@@ -564,8 +591,9 @@ Operating System    Kubernetes           KubeVirt              OpenShift Virtual
 \                   \             | GPU           vGPU         | GPU            vGPU
                                   | Passthrough                | Passthrough
 ================    ===========   =============   =========    =============    ===========
-Ubuntu 24.04 LTS    1.32---1.36   0.36+           
-Ubuntu 22.04 LTS    1.32---1.36   0.36+           0.59.1+
+Ubuntu 26.04 LTS    1.33---1.36   0.36+
+Ubuntu 24.04 LTS    1.33---1.36   0.36+
+Ubuntu 22.04 LTS    1.33---1.36   0.36+           0.59.1+
 Red Hat Core OS                                                4.18---4.22      4.18---4.22
 ================    ===========   =============   =========    =============    ===========
 
@@ -682,5 +710,5 @@ Orchestration & resource scheduling:
 
 .. note::
 
-   Run:ai requires the GPU Operator as a prerequisite and works with default GPU Operator settings. 
+   Run:ai requires the GPU Operator as a prerequisite and works with default GPU Operator settings.
    Running the GPU Operator with Container Device Interface (CDI) enabled (default in v25.10.0 and later) requires Run:ai v2.24.38 and later, or v2.23.35 and later. Refer to the Run:ai `cluster requirements documentation <https://run-ai-docs.nvidia.com/self-hosted/getting-started/installation/install-using-helm/system-requirements#nvidia-gpu-operator>`_ for more information.

--- a/gpu-operator/precompiled-drivers.rst
+++ b/gpu-operator/precompiled-drivers.rst
@@ -41,15 +41,12 @@ Limitations and Restrictions
 ============================
 
 * Support for deploying the driver containers with precompiled drivers is limited to
-  hosts with the x86_64 architecture and operating system versions listed in the :ref:`supported-precompiled-drivers` table.
+  operating system, kernel version, and driver versions listed in the :ref:`supported-precompiled-drivers` table.
 
   For information about using precompiled drivers with OpenShift Container Platform,
   refer to :external+ocp:doc:`gpu-operator-with-precompiled-drivers`.
 
-* NVIDIA supports precompiled driver containers for the most recently released long-term
-  servicing branch (LTSB) driver branch.
-
-* NVIDIA builds images for the ``aws``, ``azure``, ``generic``, ``nvidia``, and ``oracle`` kernel variants.
+* NVIDIA builds images for the ``aws``, ``azure``, ``azure-fde``, ``generic``, ``nvidia``, and ``oracle`` kernel variants.
   If your hosts run a different kernel variant, you can build a precompiled driver image
   and use your own container registry.
 


### PR DESCRIPTION
Hopefully the goals for this PR are sufficiently targeted.

- Add Ubuntu 26.04 to support.
- Identify which pre-comp drivers we make.
- Remove CentOS cruft from the air-gap page.