### PR TITLE
fix: use full semver when substituting toolkit version in docs

### DIFF
--- a/repo.toml
+++ b/repo.toml
@@ -111,7 +111,7 @@ docs_root = "${root}/container-toolkit"
 project = "container-toolkit"
 name = "NVIDIA Container Toolkit"
 version = "1.20"
-source_substitutions = {version = "1.20"}
+source_substitutions = {version = "1.20.0"}
 copyright_start = 2020
 redirects = [
   { path="concepts.html", target="index.html" },


### PR DESCRIPTION
The toolkit [install guide](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/install-guide.html) is currently broken because the following command:
```
$ export NVIDIA_CONTAINER_TOOLKIT_VERSION=1.20-1
  sudo apt-get install -y \
      nvidia-container-toolkit=${NVIDIA_CONTAINER_TOOLKIT_VERSION} \
      nvidia-container-toolkit-base=${NVIDIA_CONTAINER_TOOLKIT_VERSION} \
      libnvidia-container-tools=${NVIDIA_CONTAINER_TOOLKIT_VERSION} \
      libnvidia-container1=${NVIDIA_CONTAINER_TOOLKIT_VERSION}
```
should be:
```
$ export NVIDIA_CONTAINER_TOOLKIT_VERSION=1.20.0-1
  sudo apt-get install -y \
      nvidia-container-toolkit=${NVIDIA_CONTAINER_TOOLKIT_VERSION} \
      nvidia-container-toolkit-base=${NVIDIA_CONTAINER_TOOLKIT_VERSION} \
      libnvidia-container-tools=${NVIDIA_CONTAINER_TOOLKIT_VERSION} \
      libnvidia-container1=${NVIDIA_CONTAINER_TOOLKIT_VERSION}
```
