### PR TITLE
fix: Clarify the graphics and display driver capabilities

### DIFF
--- a/container-toolkit/docker-specialized.md
+++ b/container-toolkit/docker-specialized.md
@@ -174,14 +174,14 @@ The following table describes the supported driver capabilities:
       - Description
 
     * - ``compute``
-      - Required for CUDA and OpenCL applications. When present on the host,
+      - required for CUDA and OpenCL applications. When present on the host,
         the NVIDIA OpenCL ICD file is also available in the container.
 
     * - ``compat32``
       - required for running 32-bit applications.
 
     * - ``graphics``
-      - Required for running OpenGL, EGL, and Vulkan applications.
+      - required for rendering OpenGL, EGL, and Vulkan applications.
 
     * - ``utility``
       - required for using ``nvidia-smi`` and NVML.
@@ -190,8 +190,14 @@ The following table describes the supported driver capabilities:
       - required for using the Video Codec SDK.
 
     * - ``display``
-      - required for leveraging X11 display.
+      - required for displaying X11 or Wayland windows. Implies ``graphics``.
 ```
+
+:::{note}
+`NVIDIA_DRIVER_CAPABILITIES` replaces the default capabilities rather than adding to them, so list every
+capability your application needs. An application that displays 3D rendered output on X11 or Wayland requires
+`compute,utility,graphics,display`, for instance.
+:::
 
 For example, to allow usage of CUDA and NVML, specify the `compute` and `utility` capabilities:
 


### PR DESCRIPTION
Reviewer: @cdesiniotis @henry118 

Please feel free to edit my branch as required.

## Summary

The driver capability table describes `graphics` as *"Required for running OpenGL, EGL, and Vulkan applications"* and `display` as *"required for leveraging X11 display."* A user with a Vulkan or OpenGL application that displays its output follows that to `graphics` alone and ends up with a driver that cannot present.

## Changes

- `graphics` — required for rendering OpenGL, EGL, and Vulkan applications.
- `display` — required for displaying X11 or Wayland windows; implies `graphics`.
- A short note that `NVIDIA_DRIVER_CAPABILITIES` replaces the default capabilities rather than adding to them, with `compute,graphics,display` as the example.
- `compute` and `graphics` began their descriptions with a capital `Required` while the other four rows did not; all six now match.

## Why

Measured on NVIDIA Container Toolkit and libnvidia-container 1.20.0, driver 580.178.04, 2x Tesla P100, against an NVIDIA-driven X server, with the capability string as the only variable between runs:

```
compute,graphics          no /dev/nvidia-modeset
                          vkGetPhysicalDeviceSurfacePresentModesKHR  VkResult=-13

compute,graphics,display  /dev/nvidia-modeset present
                          vkGetPhysicalDeviceSurfacePresentModesKHR  VkResult=0
                          vkCreateSwapchainKHR                       VkResult=0
```

Two things follow that the page does not say today:

1. `graphics` is not sufficient for an application that displays its output. `display` supplies `/dev/nvidia-modeset`, which the NVIDIA client driver needs for its window-system integration. This is not X11-specific — the same applies to Wayland and to off-screen surfaces where no X server is involved, so describing `display` as being for X11 is incomplete.

2. Because the variable replaces the default set rather than extending it, `graphics,display` on its own silently drops `compute` and the application fails to start at all. The value that works is `compute,graphics,display`.

## Related

- NVIDIA/nvidia-container-toolkit#1979 and NVIDIA/nvidia-container-toolkit#1980 (merged) — the device node and graphics configuration halves of this work.
- NVIDIA/libnvidia-container#388 — discussion of the `graphics` / `display` boundary that this wording settles on the documentation side.