### PR TITLE
fix: Post-release updates

### DIFF
--- a/gpu-operator/getting-started.rst
+++ b/gpu-operator/getting-started.rst
@@ -56,7 +56,7 @@ Prerequisites
    For worker nodes or node groups that run CPU workloads only, the nodes can run any operating system because
    the GPU Operator does not perform any configuration or management of nodes for CPU-only workloads.
 
-   If you are planning to use NVIDIA GPU Driver Custom Resource Definition, you can use a mix of operating system versions on CPU and GPU nodes. Refer to the :doc:`NVIDIA GPU Driver Custom Resource Definition <gpu-driver-configuration>` page for more information.
+   If you are planning to use NVIDIA GPU Driver Custom Resource Definition, you can use a mix of operating system versions on CPU and GPU nodes. Refer to the :doc:`NVIDIA Driver Custom Resource Definition <nvidia-driver-configuration>` page for more information.
 
 #. Nodes must be configured with a container engine such as CRI-O or containerd.
 
@@ -470,7 +470,7 @@ To view all the options, run ``helm show values nvidia/gpu-operator``.
 
    * - ``driver.nvidiaDriverCRD.enabled``
      - When set to ``true``, the Operator deploys NVIDIA GPU Driver Custom Resource Definition.
-       Refer to the :doc:`NVIDIA GPU Driver Custom Resource Definition <gpu-driver-configuration>` page for more information.
+       Refer to the :doc:`NVIDIA Driver Custom Resource Definition <nvidia-driver-configuration>` page for more information.
      - ``false``
 
    * - ``driver.repository``
@@ -540,7 +540,7 @@ To view all the options, run ``helm show values nvidia/gpu-operator``.
        When set to ``true``, the GDRCopy Driver runs as a sidecar container in the GPU driver pod.
        For information about GDRCopy, refer to the `gdrcopy <https://developer.nvidia.com/gdrcopy>`__ page.
 
-       You can enable GDRCopy if you use the :doc:`gpu-driver-configuration`.
+       You can enable GDRCopy if you use the :doc:`nvidia-driver-configuration`.
      - ``false``
 
 
@@ -899,6 +899,6 @@ After verifying the installation, you can configure the GPU Operator for your wo
 - :doc:`gpu-operator-mig` — Configure Multi-Instance GPU (MIG) partitioning on supported GPUs.
 - :doc:`gpu-operator-rdma` — Enable GPUDirect RDMA for high-performance networking.
 - :doc:`dra-intro-install` — Allocate GPUs by using Kubernetes Dynamic Resource Allocation (DRA).
-- :doc:`gpu-driver-configuration` — Use the NVIDIA GPU Driver Custom Resource Definition to manage drivers per node.
+- :doc:`nvidia-driver-configuration` — Use the NVIDIA GPU Driver Custom Resource Definition to manage drivers per node.
 - :doc:`precompiled-drivers` — Speed up driver deployments with precompiled kernel modules.
 - :doc:`cdi` — Learn about Container Device Interface (CDI) and NRI Plugin mode.

--- a/gpu-operator/getting-started.rst
+++ b/gpu-operator/getting-started.rst
@@ -94,16 +94,29 @@ Use ``--set`` options to customize the deployment for your environment.
    For installation on Red Hat OpenShift Container Platform,
    refer to :external+ocp:doc:`steps-overview`.
 
-#. Add the NVIDIA Helm repository:
+#. Choose how to access the GPU Operator Helm chart:
 
-   .. code-block:: console
+   - To install the chart as an OCI artifact, no Helm repository setup is required.
 
-      $ helm repo add nvidia https://helm.ngc.nvidia.com/nvidia \
-          && helm repo update
+   - To use the classic NVIDIA Helm repository, add and update the repository:
+
+     .. code-block:: console
+
+        $ helm repo add nvidia https://helm.ngc.nvidia.com/nvidia \
+            && helm repo update
 
 #. Install the GPU Operator.
 
-   - Install the Operator with the default configuration:
+   - Install the Operator from the OCI artifact with the default configuration:
+
+     .. code-block:: console
+
+        $ helm install --wait gpu-operator \
+            -n gpu-operator --create-namespace \
+            oci://nvcr.io/nvidia/cloud-native-charts/gpu-operator \
+            --version=${version}
+
+   - Install the Operator from the classic Helm repository with the default configuration:
 
      .. code-block:: console
 
@@ -112,7 +125,7 @@ Use ``--set`` options to customize the deployment for your environment.
             nvidia/gpu-operator \
             --version=${version}
 
-   - Install the Operator and specify configuration options:
+   - Install the Operator from the classic Helm repository and specify configuration options:
 
      .. code-block:: console
 

--- a/gpu-operator/gpu-operator-kubevirt-dra.rst
+++ b/gpu-operator/gpu-operator-kubevirt-dra.rst
@@ -269,6 +269,11 @@ Verify DRA Resources
 
       $ kubectl get resourceslice <slice-name> -o yaml
 
+   The driver publishes partition membership through attributes named ``partitionN``,
+   where ``N`` is ``1``, ``2``, ``4``, or ``8`` and specifies the number of GPUs in the partition.
+   The attribute value is the Fabric Manager partition ID.
+   For example, ``partition2: 4`` indicates that the GPU belongs to two-GPU partition 4.
+
    Confirm that devices with the ``gpu.nvidia.com/type`` attribute set to
    ``vfio`` include a ``gpuModuleID`` attribute and the ``partitionN`` attributes
    reported for the hardware. For the two-GPU example in this procedure, at

--- a/gpu-operator/gpu-operator-kubevirt-dra.rst
+++ b/gpu-operator/gpu-operator-kubevirt-dra.rst
@@ -65,7 +65,7 @@ Assumptions, Constraints, and Dependencies
   You could also use labels and node selectors to avoid the race condition.
   Refer to `Limitations and Considerations <https://dra-driver-nvidia-gpu.sigs.k8s.io/docs/guides/gpu-allocation/kubevirt-vfio-gpu-passthrough/#limitations-and-considerations>`__ in the DRA driver documentation for more information.
 
-* DCGM and DGCM-Exporter cannot be enabled on the KubeVirt nodes.
+* DCGM and DCGM Exporter cannot be enabled on the KubeVirt nodes.
 * GPU Operator does not install the NVIDIA driver in the guest operating system.
 
 *************
@@ -172,17 +172,26 @@ Pre-Installed Driver
       $ sudo systemctl start nvidia-fabricmanager
       $ sudo systemctl status nvidia-fabricmanager
 
+******************************
+Disable DCGM and DCGM Exporter
+******************************
+
+DCGM and DCGM Exporter are not supported on KubeVirt nodes that use VFIO passthrough.
+Both operands keep NVIDIA client connections open and prevent the driver from rebinding a GPU to the VFIO driver.
+
+Disable both operands in the ``GPUCluster`` resource before you enable VFIO support:
+
+.. code-block:: console
+   :force:
+
+   $ kubectl patch gpucluster gpu-cluster \
+       --type=merge -p '{"spec":{"dcgm":{"enabled":false},"dcgmExporter":{"enabled":false}}}'
+
 ****************************
 Enable VFIO Support with DRA
 ****************************
 
 Enable ``PassthroughSupport`` and ``DeviceMetadata`` in the ``GPUCluster`` resource.
-
-#. Isolate GPU consumers that would keep NVIDIA clients open during VFIO rebinding:
-
-   .. code-block:: console
-
-      $ kubectl patch gpucluster gpu-cluster --type=merge -p '{"spec":{"dcgmExporter":{"enabled":false}}}'
 
 #. Add the feature gates under ``spec.draDriver.featureGates``.
    Preserve any other DRA driver settings:
@@ -197,13 +206,26 @@ Enable ``PassthroughSupport`` and ``DeviceMetadata`` in the ``GPUCluster`` resou
                   "computeDomains":{"enabled":false},
                   "featureGates":{
                     "PassthroughSupport":true,
-                    "DeviceMetadata":true,
-                    "FabricManagerPartitioning":true  # For NVLink 5 or later systems with NVSwitch-managed fabric.
+                    "DeviceMetadata":true
                   }}}}'
 
    ``PassthroughSupport`` enables allocation with ``VfioDeviceConfig``.
    ``DeviceMetadata`` provides KubeVirt with the PCI address for each allocated device and exposes the VFIO API device to the ``virt-launcher`` pod.
    GPU Operator continues to manage the DRA driver, DeviceClasses, RBAC, and operand lifecycle.
+
+#. Optional: If you configured Fabric Manager partitioning, also enable the ``FabricManagerPartitioning`` feature gate.
+   Perform this step only on supported HGX or single-node NVL systems with an NVSwitch-managed fabric:
+
+   .. code-block:: console
+      :force:
+
+      $ kubectl patch gpucluster gpu-cluster \
+          --type=merge -p '{
+              "spec":{
+                "draDriver":{
+                  "featureGates":{
+                    "FabricManagerPartitioning":true  # For NVLink 5 or later systems with NVSwitch-managed fabric.
+                  }}}}'
 
 #. Wait until GPU Operator finishes reconciling the change:
 

--- a/gpu-operator/index.rst
+++ b/gpu-operator/index.rst
@@ -47,7 +47,7 @@
    Outdated Kernels <install-gpu-operator-outdated-kernels.rst>
    Custom GPU Driver Parameters <custom-driver-params.rst>
    precompiled-drivers.rst
-   GPU Driver CRD <gpu-driver-configuration.rst>
+   NVIDIA Driver CRD <nvidia-driver-configuration.rst>
    CDI and NRI Support <cdi.rst>
 
 .. toctree::

--- a/gpu-operator/life-cycle-policy.rst
+++ b/gpu-operator/life-cycle-policy.rst
@@ -127,10 +127,10 @@ Refer to :ref:`Upgrading the NVIDIA GPU Operator` for more information.
      - ${version}
 
    * - NVIDIA KubeVirt GPU Device Plugin
-     - `v1.5.0 <https://github.com/NVIDIA/kubevirt-gpu-device-plugin>`__
+     - `v1.6.0 <https://github.com/NVIDIA/kubevirt-gpu-device-plugin>`__
 
    * - NVIDIA vGPU Device Manager
-     - `v0.4.2 <https://github.com/NVIDIA/vgpu-device-manager>`__
+     - `v0.5.0 <https://github.com/NVIDIA/vgpu-device-manager>`__
 
    * - NVIDIA GDS Driver |gds|_
      - `2.29.4 <https://github.com/NVIDIA/gds-nvidia-fs/releases>`__

--- a/gpu-operator/life-cycle-policy.rst
+++ b/gpu-operator/life-cycle-policy.rst
@@ -29,7 +29,7 @@ NVIDIA GPU Operator Versioning
 NVIDIA GPU Operator is versioned following the calendar versioning convention.
 
 The version follows the pattern ``YY.MM.PP``, such as 23.6.0, 23.6.1, and 23.9.0.
-The first two fields, ``YY.MM`` identify a major version and indicates when the major version was initially released.
+The first two fields, ``YY.MM``, identify a major version and indicate when the major version was initially released.
 The third field, ``PP``, identifies the patch version of the major version.
 Patch releases typically include critical bug and CVE fixes, but can include minor features.
 
@@ -39,7 +39,7 @@ NVIDIA GPU Operator Life Cycle
 ******************************
 
 When a new major version of NVIDIA GPU Operator is released, the previous major version enters deprecated support and only receives patch release updates for critical bug and CVE fixes.
-All prior major versions enter end of support and are no longer supported and do not receive patch release updates.
+All prior major versions reach end of support and no longer receive patch release updates.
 
 The product life cycle and versioning are subject to change in the future.
 
@@ -53,7 +53,7 @@ The product life cycle and versioning are subject to change in the future.
    * - GPU Operator Version
      - Status
 
-   * - 26.6.x
+   * - 26.7.x
      - Supported
 
    * - 26.3.x
@@ -80,7 +80,7 @@ When post-release testing confirms support for newer versions of operands, these
 Refer to :ref:`Upgrading the NVIDIA GPU Operator` for more information.
 
 .. note::
-  All the following components are supported as :ref:`government-ready <install-gpu-operator-gov-ready>` in the NVIDIA GPU Operator v26.3, except for NVIDIA GDS Driver, NVIDIA Confidential Computing Manager, and NVIDIA GDRCopy Driver.
+  All of the following components are supported as :ref:`government-ready <install-gpu-operator-gov-ready>` in the NVIDIA GPU Operator v26.7, except for NVIDIA GDS Driver, NVIDIA Confidential Computing Manager, and NVIDIA GDRCopy Driver.
 
 **D** = Default driver, **R** = Recommended driver
 

--- a/gpu-operator/nvidia-driver-configuration.rst
+++ b/gpu-operator/nvidia-driver-configuration.rst
@@ -17,14 +17,18 @@
 
 .. headings (h1/h2/h3/h4/h5) are # * = -
 
-############################################
-NVIDIA GPU Driver Custom Resource Definition
-############################################
+.. _nvidia-gpu-driver-custom-resource-definition:
+
+########################################
+NVIDIA Driver Custom Resource Definition
+########################################
 
 
-*****************************************************
-Overview of the GPU Driver Custom Resource Definition
-*****************************************************
+.. _overview-of-the-gpu-driver-custom-resource-definition:
+
+********************************************************
+Overview of the NVIDIA Driver Custom Resource Definition
+********************************************************
 
 You can create one or more instances of an NVIDIA driver (``NVIDIADriver``) custom resource
 to specify the NVIDIA GPU driver type and driver version to configure on specific nodes.
@@ -161,7 +165,7 @@ Custom Driver Parameters
   For more information, refer to :doc:`Customizing NVIDIA GPU Driver Parameters during Installation <custom-driver-params>`.
 
 
-.. _migrate-clusterpolicy-to-nvidiadriver:
+.. _migrating-from-cluster-policy-driver-management:
 
 ***********************************************
 Migrating from Cluster Policy Driver Management
@@ -348,8 +352,8 @@ The following table describes some of the fields in the custom resource.
 
    * - ``kernelModuleType``
      - Specifies the type of the NVIDIA GPU Kernel modules to use.
-       Valid values are ``auto`` (default), ``proprietary``, and ``open``. 
-       
+       Valid values are ``auto`` (default), ``proprietary``, and ``open``.
+
        ``Auto`` means that the recommended kernel module type is chosen based on the GPU devices on the host and the driver branch used.
      - ``auto``
 
@@ -384,7 +388,7 @@ The following table describes some of the fields in the custom resource.
      - ``nvcr.io/nvidia``
 
    * - ``useOpenKernelModules`` Deprecated.
-     - This field is deprecated as of v25.3.0 and will be ignored. Use ``kernelModuleType`` instead. 
+     - This field is deprecated as of v25.3.0 and will be ignored. Use ``kernelModuleType`` instead.
        Specifies to use the NVIDIA Open GPU Kernel modules.
      - ``false``
 
@@ -576,10 +580,11 @@ Precompiled Driver Container on Some Nodes
 
 
 .. _nvd-upgrade:
+.. _upgrading-the-nvidia-gpu-driver:
 
-*******************************
-Upgrading the NVIDIA GPU Driver
-*******************************
+***************************
+Upgrading the NVIDIA Driver
+***************************
 
 To upgrade a driver managed by an NVIDIA driver custom resource, update the ``spec.version`` field.
 The upgrade controller applies the resource's ``spec.upgradePolicy`` to the nodes that it manages.

--- a/gpu-operator/overview.rst
+++ b/gpu-operator/overview.rst
@@ -77,129 +77,89 @@ By installing and using the GPU Operator, you accept the terms and conditions of
 
 .. list-table::
    :header-rows: 1
-   :widths: 30 10 60
+   :widths: 25 10 40 25
 
    * - Component
      - Artifact Type
      - Artifact Licenses
+     - Third-Party Licenses
 
    * - NVIDIA GPU Operator
      - Helm Chart
      - `Apache 2.0 <https://www.apache.org/licenses/LICENSE-2.0>`__
+     - `THIRD_PARTY_NOTICES.md <https://github.com/NVIDIA/gpu-operator/blob/main/THIRD_PARTY_NOTICES.md>`__
 
    * - NVIDIA GPU Operator
      - Image
      - |pstai|_
+     - `THIRD_PARTY_NOTICES.md <https://github.com/NVIDIA/gpu-operator/blob/main/THIRD_PARTY_NOTICES.md>`__
 
    * - NVIDIA GPU Driver
      - Image
      - `License for Customer Use of NVIDIA Software <http://www.nvidia.com/content/DriverDownload-March2009/licence.php?lang=us>`__
 
        |pstai|_
+     - --
 
    * - NVIDIA Container Toolkit
      - Image
      - |pstai|_
+     - `THIRD_PARTY_NOTICES.md <https://github.com/NVIDIA/nvidia-container-toolkit/blob/main/THIRD_PARTY_NOTICES.md>`__
 
    * - NVIDIA Kubernetes Device Plugin
      - Image
      - |pstai|_
+     - `THIRD_PARTY_NOTICES.md <https://github.com/NVIDIA/k8s-device-plugin/blob/main/THIRD_PARTY_NOTICES.md>`__
 
    * - NVIDIA MIG Manager for Kubernetes
      - Image
      - |pstai|_
+     - `THIRD_PARTY_NOTICES.md <https://github.com/NVIDIA/mig-parted/blob/main/THIRD_PARTY_NOTICES.md>`__
 
    * - Validator for NVIDIA GPU Operator
      - Image
      - |pstai|_
+     - `THIRD_PARTY_NOTICES.md <https://github.com/NVIDIA/gpu-operator/blob/main/THIRD_PARTY_NOTICES.md>`__
 
    * - NVIDIA DCGM
      - Image
      - |pstai|_
+     - --
 
    * - NVIDIA DCGM Exporter
      - Image
      - |pstai|_
+     - --
 
    * - NVIDIA Driver Manager for Kubernetes
      - Image
      - |pstai|_
+     - `THIRD_PARTY_NOTICES.md <https://github.com/NVIDIA/k8s-driver-manager/blob/main/THIRD_PARTY_NOTICES.md>`__
 
    * - NVIDIA KubeVirt GPU Device Plugin
      - Image
      - |pstai|_
+     - `THIRD_PARTY_NOTICES.md <https://github.com/NVIDIA/kubevirt-gpu-device-plugin/blob/master/THIRD_PARTY_NOTICES.md>`__
 
    * - NVIDIA vGPU Device Manager
      - Image
      - |pstai|_
+     - `THIRD_PARTY_NOTICES.md <https://github.com/NVIDIA/vgpu-device-manager/blob/main/THIRD_PARTY_NOTICES.md>`__
 
    * - NVIDIA GDS Driver
      - Image
      - `License for Customer Use of NVIDIA Software <http://www.nvidia.com/content/DriverDownload-March2009/licence.php?lang=us>`__
 
        |pstai|_
+     - --
 
    * - NVIDIA Confidential Computing
        Manager for Kubernetes
      - Image
      - |pstai|_
+     - `THIRD_PARTY_NOTICES.md <https://github.com/NVIDIA/k8s-cc-manager/blob/main/THIRD_PARTY_NOTICES.md>`__
 
    * - NVIDIA GDRCopy Driver
      - Image
      - |pstai|_
-
-
-Third-Party Notices by GPU Operator Release
--------------------------------------------
-
-The following table maps each GPU Operator patch release to the exact component release and third-party notices.
-
-.. flat-table::
-   :header-rows: 2
-
-   * - :rspan:`1` Component
-     - GPU Operator Version
-
-   * - v26.7.0
-
-   * - NVIDIA GPU Operator Helm chart and image
-     - | v26.7.0
-       | `THIRD_PARTY_NOTICES.md <https://github.com/NVIDIA/gpu-operator/blob/v26.7.0/THIRD_PARTY_NOTICES.md>`__
-
-   * - Validator for NVIDIA GPU Operator
-     - | v26.7.0
-       | `THIRD_PARTY_NOTICES.md <https://github.com/NVIDIA/gpu-operator/blob/v26.7.0/THIRD_PARTY_NOTICES.md>`__
-
-   * - NVIDIA Container Toolkit
-     - | v1.20.0
-       | `THIRD_PARTY_NOTICES.md <https://github.com/NVIDIA/nvidia-container-toolkit/blob/v1.20.0/THIRD_PARTY_NOTICES.md>`__
-
-   * - NVIDIA Kubernetes Device Plugin
-     - | v0.20.0
-       | `THIRD_PARTY_NOTICES.md <https://github.com/NVIDIA/k8s-device-plugin/blob/v0.20.0/THIRD_PARTY_NOTICES.md>`__
-
-   * - NVIDIA MIG Manager for Kubernetes
-     - | v0.15.0
-       | `THIRD_PARTY_NOTICES.md <https://github.com/NVIDIA/mig-parted/blob/v0.15.0/THIRD_PARTY_NOTICES.md>`__
-
-   * - NVIDIA Driver Manager for Kubernetes
-     - | v0.12.0
-       | `THIRD_PARTY_NOTICES.md <https://github.com/NVIDIA/k8s-driver-manager/blob/v0.12.0/THIRD_PARTY_NOTICES.md>`__
-
-   * - NVIDIA KubeVirt GPU Device Plugin
-     - | v1.6.0
-       | `THIRD_PARTY_NOTICES.md <https://github.com/NVIDIA/kubevirt-gpu-device-plugin/blob/v1.6.0/THIRD_PARTY_NOTICES.md>`__
-
-   * - NVIDIA vGPU Device Manager
-     - | v0.5.0
-       | `THIRD_PARTY_NOTICES.md <https://github.com/NVIDIA/vgpu-device-manager/blob/v0.5.0/THIRD_PARTY_NOTICES.md>`__
-
-   * - NVIDIA Confidential Computing
-       Manager for Kubernetes
-     - | v0.4.3
-       | `THIRD_PARTY_NOTICES.md <https://github.com/NVIDIA/k8s-cc-manager/blob/v0.4.3/THIRD_PARTY_NOTICES.md>`__
-
-   * - NVIDIA GDRCopy Driver
-     - | v2.6
-       | The notices are published with each operating-system-specific image in the `NGC Catalog <https://catalog.ngc.nvidia.com/orgs/nvidia/cloud-native/containers/gdrdrv/->`__.
-         Select the image tag that matches your host operating system.
+     - `Third-Party Notices <https://catalog.ngc.nvidia.com/orgs/nvidia/cloud-native/containers/gdrdrv/->`__

--- a/gpu-operator/overview.rst
+++ b/gpu-operator/overview.rst
@@ -72,94 +72,134 @@ more information on how to contribute and the release artifacts.
 The base images used by the software might include software that is licensed under open-source licenses such as GPL.
 The source code for these components is archived on the CUDA opensource `index <https://developer.download.nvidia.com/compute/cuda/opensource/>`_.
 
-The following table identifieis the licenses for the Operator and software components.
+The following table identifies the licenses for the Operator and software components.
 By installing and using the GPU Operator, you accept the terms and conditions of these licenses.
 
 .. list-table::
    :header-rows: 1
-   :widths: 25 10 40 25
+   :widths: 30 10 60
 
    * - Component
      - Artifact Type
      - Artifact Licenses
-     - Third-Party Licenses
 
    * - NVIDIA GPU Operator
      - Helm Chart
      - `Apache 2.0 <https://www.apache.org/licenses/LICENSE-2.0>`__
-     - `THIRD_PARTY_NOTICES.md <https://github.com/NVIDIA/gpu-operator/blob/main/THIRD_PARTY_NOTICES.md>`__
 
    * - NVIDIA GPU Operator
      - Image
      - |pstai|_
-     - `THIRD_PARTY_NOTICES.md <https://github.com/NVIDIA/gpu-operator/blob/main/THIRD_PARTY_NOTICES.md>`__
 
    * - NVIDIA GPU Driver
      - Image
      - `License for Customer Use of NVIDIA Software <http://www.nvidia.com/content/DriverDownload-March2009/licence.php?lang=us>`__
 
        |pstai|_
-     - --
 
    * - NVIDIA Container Toolkit
      - Image
      - |pstai|_
-     - `THIRD_PARTY_NOTICES.md <https://github.com/NVIDIA/nvidia-container-toolkit/blob/main/THIRD_PARTY_NOTICES.md>`__
 
    * - NVIDIA Kubernetes Device Plugin
      - Image
      - |pstai|_
-     - `THIRD_PARTY_NOTICES.md <https://github.com/NVIDIA/k8s-device-plugin/blob/main/THIRD_PARTY_NOTICES.md>`__
 
    * - NVIDIA MIG Manager for Kubernetes
      - Image
      - |pstai|_
-     - `THIRD_PARTY_NOTICES.md <https://github.com/NVIDIA/mig-parted/blob/main/THIRD_PARTY_NOTICES.md>`__
 
    * - Validator for NVIDIA GPU Operator
      - Image
      - |pstai|_
-     - `THIRD_PARTY_NOTICES.md <https://github.com/NVIDIA/gpu-operator/blob/main/THIRD_PARTY_NOTICES.md>`__
 
    * - NVIDIA DCGM
      - Image
      - |pstai|_
-     - --
 
    * - NVIDIA DCGM Exporter
      - Image
      - |pstai|_
-     - --
 
    * - NVIDIA Driver Manager for Kubernetes
      - Image
      - |pstai|_
-     - `THIRD_PARTY_NOTICES.md <https://github.com/NVIDIA/k8s-driver-manager/blob/main/THIRD_PARTY_NOTICES.md>`__
 
    * - NVIDIA KubeVirt GPU Device Plugin
      - Image
      - |pstai|_
-     - `THIRD_PARTY_NOTICES.md <https://github.com/NVIDIA/kubevirt-gpu-device-plugin/blob/master/THIRD_PARTY_NOTICES.md>`__
 
    * - NVIDIA vGPU Device Manager
      - Image
      - |pstai|_
-     - `THIRD_PARTY_NOTICES.md <https://github.com/NVIDIA/vgpu-device-manager/blob/main/THIRD_PARTY_NOTICES.md>`__
 
    * - NVIDIA GDS Driver
      - Image
      - `License for Customer Use of NVIDIA Software <http://www.nvidia.com/content/DriverDownload-March2009/licence.php?lang=us>`__
 
        |pstai|_
-     - --
 
    * - NVIDIA Confidential Computing
        Manager for Kubernetes
      - Image
      - |pstai|_
-     - `THIRD_PARTY_NOTICES.md <https://github.com/NVIDIA/k8s-cc-manager/blob/main/THIRD_PARTY_NOTICES.md>`__
 
    * - NVIDIA GDRCopy Driver
      - Image
      - |pstai|_
-     - `Third-Party Notices <https://catalog.ngc.nvidia.com/orgs/nvidia/cloud-native/containers/gdrdrv/->`__
+
+
+Third-Party Notices by GPU Operator Release
+-------------------------------------------
+
+The following table maps each GPU Operator patch release to the exact component release and third-party notices.
+
+.. flat-table::
+   :header-rows: 2
+
+   * - :rspan:`1` Component
+     - GPU Operator Version
+
+   * - v26.7.0
+
+   * - NVIDIA GPU Operator Helm chart and image
+     - | v26.7.0
+       | `THIRD_PARTY_NOTICES.md <https://github.com/NVIDIA/gpu-operator/blob/v26.7.0/THIRD_PARTY_NOTICES.md>`__
+
+   * - Validator for NVIDIA GPU Operator
+     - | v26.7.0
+       | `THIRD_PARTY_NOTICES.md <https://github.com/NVIDIA/gpu-operator/blob/v26.7.0/THIRD_PARTY_NOTICES.md>`__
+
+   * - NVIDIA Container Toolkit
+     - | v1.20.0
+       | `THIRD_PARTY_NOTICES.md <https://github.com/NVIDIA/nvidia-container-toolkit/blob/v1.20.0/THIRD_PARTY_NOTICES.md>`__
+
+   * - NVIDIA Kubernetes Device Plugin
+     - | v0.20.0
+       | `THIRD_PARTY_NOTICES.md <https://github.com/NVIDIA/k8s-device-plugin/blob/v0.20.0/THIRD_PARTY_NOTICES.md>`__
+
+   * - NVIDIA MIG Manager for Kubernetes
+     - | v0.15.0
+       | `THIRD_PARTY_NOTICES.md <https://github.com/NVIDIA/mig-parted/blob/v0.15.0/THIRD_PARTY_NOTICES.md>`__
+
+   * - NVIDIA Driver Manager for Kubernetes
+     - | v0.12.0
+       | `THIRD_PARTY_NOTICES.md <https://github.com/NVIDIA/k8s-driver-manager/blob/v0.12.0/THIRD_PARTY_NOTICES.md>`__
+
+   * - NVIDIA KubeVirt GPU Device Plugin
+     - | v1.6.0
+       | `THIRD_PARTY_NOTICES.md <https://github.com/NVIDIA/kubevirt-gpu-device-plugin/blob/v1.6.0/THIRD_PARTY_NOTICES.md>`__
+
+   * - NVIDIA vGPU Device Manager
+     - | v0.5.0
+       | `THIRD_PARTY_NOTICES.md <https://github.com/NVIDIA/vgpu-device-manager/blob/v0.5.0/THIRD_PARTY_NOTICES.md>`__
+
+   * - NVIDIA Confidential Computing
+       Manager for Kubernetes
+     - | v0.4.3
+       | `THIRD_PARTY_NOTICES.md <https://github.com/NVIDIA/k8s-cc-manager/blob/v0.4.3/THIRD_PARTY_NOTICES.md>`__
+
+   * - NVIDIA GDRCopy Driver
+     - | v2.6
+       | The notices are published with each operating-system-specific image in the `NGC Catalog <https://catalog.ngc.nvidia.com/orgs/nvidia/cloud-native/containers/gdrdrv/->`__.
+         Select the image tag that matches your host operating system.

--- a/gpu-operator/platform-support.rst
+++ b/gpu-operator/platform-support.rst
@@ -331,7 +331,7 @@ Bare Metal / Virtual Machines with GPU Passthrough and NVIDIA vGPU
       - 1.33---1.36
       - 1.33---1.36
       - 1.33---1.36
-      - 1.33---1.35
+      - 1.33---1.36
       - 2.17
 
     * - Ubuntu 24.04 LTS
@@ -341,7 +341,7 @@ Bare Metal / Virtual Machines with GPU Passthrough and NVIDIA vGPU
       - 1.33---1.36
       - 1.33---1.36
       - 1.33---1.36
-      - 1.33---1.35
+      - 1.33---1.36
       - 2.17
 
     * - Ubuntu 22.04 LTS |fn2|_
@@ -351,7 +351,7 @@ Bare Metal / Virtual Machines with GPU Passthrough and NVIDIA vGPU
       - 1.33---1.36
       - 1.33---1.36
       - 1.33---1.36
-      - 1.33---1.35
+      - 1.33---1.36
       - 2.15 2.16 2.17
 
     * - Red Hat Core OS
@@ -483,16 +483,21 @@ Cloud Service Providers
         | Kubernetes
       - | Google GKE
         | Kubernetes
+      - | Microsoft Azure
+        | Kubernetes Service
 
     * - Ubuntu 26.04 LTS
+      - 1.33---1.36
       - 1.33---1.36
       - 1.33---1.36
 
     * - Ubuntu 24.04 LTS
       - 1.33---1.36
       - 1.33---1.36
+      - 1.33---1.36
 
     * - Ubuntu 22.04 LTS
+      - 1.33---1.36
       - 1.33---1.36
       - 1.33---1.36
 
@@ -558,6 +563,8 @@ To report an issue with the GPU Operator on one of these configurations, open an
 
 For more details about partners and their supported configurations, refer to the :external+pv:doc:`index` page.
 
+.. _supported-container-runtimes:
+
 ****************************
 Supported Container Runtimes
 ****************************
@@ -565,7 +572,7 @@ Supported Container Runtimes
 The GPU Operator has been validated for the following container runtimes:
 
 +----------------------------+------------------------+----------------+
-| Operating System           | Containerd 1.8 - 2.3   | CRI-O          |
+| Operating System           | Containerd 2.0 - 2.3   | CRI-O          |
 +============================+========================+================+
 | Ubuntu 26.04 LTS           | Yes                    | --             |
 +----------------------------+------------------------+----------------+

--- a/gpu-operator/release-notes.rst
+++ b/gpu-operator/release-notes.rst
@@ -59,6 +59,12 @@ New Features
   - NVIDIA GDRCopy Driver v2.6
   - NVIDIA Kata Sandbox Device Plugin v0.0.5
 
+* Added the GPU Operator Helm chart as an OCI artifact in NGC.
+  You can now install the Operator directly from
+  ``oci://nvcr.io/nvidia/cloud-native-charts/gpu-operator`` as an alternative
+  to using the classic Helm repository.
+  (`Issue #2520 <https://github.com/NVIDIA/gpu-operator/issues/2520>`__)
+
 * Added support for managing the DRA Driver for NVIDIA GPUs through the GPU Operator.
   The new ``GPUCluster`` custom resource deploys and manages the DRA driver, ComputeDomain support for Multi-Node NVLink, DCGM, DCGM Exporter, and a DRA validation workload.
   Workloads can allocate full GPUs and preconfigured MIG devices through Kubernetes ``ResourceClaim`` objects and select devices by attributes.
@@ -185,6 +191,8 @@ Known Issues
 Post-Release Documentation Updates
 ----------------------------------
 
+* Added the Helm chart OCI artifact to the new features and installation
+  documentation after the artifact became available following the v26.7.0 release.
 * Updated the release notes to include the new features and enhancements to the NVIDIA driver CRD.
 * Added NVIDIA vGPU Device Manager v0.5.0 and NVIDIA KubeVirt GPU Device Plugin v1.6.0 to the software component version list.
 * The minimum :ref:`supported containerd version <supported-container-runtimes>` changed from 1.8 to 2.0.

--- a/gpu-operator/release-notes.rst
+++ b/gpu-operator/release-notes.rst
@@ -52,6 +52,8 @@ New Features
   - NVIDIA MIG Manager for Kubernetes v0.15.0
   - Node Feature Discovery v0.19.0
   - NVIDIA GPU Feature Discovery for Kubernetes v0.20.0
+  - NVIDIA vGPU Device Manager v0.5.0
+  - NVIDIA KubeVirt GPU Device Plugin v1.6.0
   - NVIDIA GDS Driver v2.29.4
   - NVIDIA Confidental Computing Manager for Kubernetes v0.4.3
   - NVIDIA GDRCopy Driver v2.6
@@ -184,6 +186,7 @@ Post-Release Documentation Updates
 ----------------------------------
 
 * Updated the release notes to include the new features and enhancements to the NVIDIA driver CRD.
+* Added NVIDIA vGPU Device Manager v0.5.0 and NVIDIA KubeVirt GPU Device Plugin v1.6.0 to the software component version list.
 * The minimum :ref:`supported containerd version <supported-container-runtimes>` changed from 1.8 to 2.0.
 * The documentation page for the NVIDIA driver CRD was renamed to :doc:`nvidia-driver-configuration`.
 * Restored Azure Kubernetes Service (AKS) to the :ref:`cloud service providers <cloud-service-providers>` table.

--- a/gpu-operator/release-notes.rst
+++ b/gpu-operator/release-notes.rst
@@ -78,6 +78,18 @@ New Features
 
   Refer to :ref:`GPU Operator with KubeVirt and DRA <gpu-operator-kubevirt-dra>` for prerequisites, limitations, and configuration.
 
+* Added the following features and enhancements to the NVIDIA driver CRD:
+
+  * Added support for :ref:`migrating from cluster policy driver management to NVIDIA driver CRD <migrating-from-cluster-policy-driver-management>`.
+    (`PR #2353 <https://github.com/NVIDIA/gpu-operator/pull/2353>`__)
+  * Added an ``upgradePolicy`` field to the NVIDIA driver custom resource definition (CRD).
+    You can now define a driver upgrade policy per NVIDIADriver custom resource.
+    When the field is unset, the driver-upgrade controller falls back to the default upgrade policy that is defined in the Helm chart values.
+    (`PR #2582 <https://github.com/NVIDIA/gpu-operator/pull/2582>`__)
+  * Added support for setting a default custom resource during installation or upgrade.
+    This default resource can co-exist with user-defined resource, and typically acts as a fallback.
+    (`PR #2355 <https://github.com/NVIDIA/gpu-operator/pull/2355>`__)
+
 * Added a ``nvidia.com/gpu.deploy.client`` node label that lets the GPU Operator manage third-party GPU client pods during driver upgrades and MIG configuration changes.
   Advanced users who run their own GPU client workloads that hold GPU device handles (for example, a standalone NVIDIA DRA driver) can add ``nvidia.com/gpu.deploy.client=true`` to the ``nodeSelector`` of the workload's DaemonSet.
   The GPU Operator then automatically restarts these pods during a driver upgrade or a MIG configuration change, so the operation can proceed without manual pod eviction.
@@ -87,11 +99,6 @@ New Features
   Previously, a chart upgrade that changed only cosmetic pod-template metadata, such as the ``helm.sh/chart`` label, evicted running GPU workloads and drained the node.
   The driver-upgrade controller now compares the driver configuration digest between the running pod and the desired DaemonSet, and when they match, it cordons the node and restarts the driver pod in place without evicting workloads or draining the node.
   (`PR #2527 <https://github.com/NVIDIA/gpu-operator/pull/2527>`__)
-
-* Added an ``upgradePolicy`` field to the NVIDIA driver custom resource definition (CRD).
-  You can now define a driver upgrade policy per NVIDIADriver custom resource.
-  When the field is unset, the driver-upgrade controller falls back to the default upgrade policy that is defined in the Helm chart values.
-  (`PR #2582 <https://github.com/NVIDIA/gpu-operator/pull/2582>`__)
 
 * Added the ``hostPaths.kubeletRootDir`` Helm value to configure a custom kubelet root directory.
   When left empty, the GPU Operator uses ``/var/lib/kubelet`` as the default path.
@@ -172,6 +179,17 @@ Known Issues
   The device that is prepared first succeeds, and preparation of the other device fails.
 
   To avoid conflicting allocations, submit the workloads serially and wait for device preparation to complete, or dedicate separate nodes to container and VFIO workloads.
+
+Post-Release Documentation Updates
+----------------------------------
+
+* Updated the release notes to include the new features and enhancements to the NVIDIA driver CRD.
+* The minimum :ref:`supported containerd version <supported-container-runtimes>` changed from 1.8 to 2.0.
+* The documentation page for the NVIDIA driver CRD was renamed to :doc:`nvidia-driver-configuration`.
+* Restored Azure Kubernetes Service (AKS) to the :ref:`cloud service providers <cloud-service-providers>` table.
+* Added support for Kubernetes 1.36 for Canonical MicroK8s to the :ref:`bare-metal` table.
+* Added a brief explanation of the ``partitionN`` attribute to the :ref:`gpu-operator-kubevirt-dra` page.
+
 
 ----
 
@@ -370,7 +388,7 @@ New Features
 
 * Added support for the NVIDIA Driver Custom Resource Definition (CRD).
   Use this feature on new cluster installations to configure multiple driver types and versions on different nodes or multiple operating system versions on nodes.
-  Refer to the :doc:`NVIDIA Driver Custom Resource Definition documentation <gpu-driver-configuration>` for more information.
+  Refer to the :doc:`NVIDIA Driver Custom Resource Definition documentation <nvidia-driver-configuration>` for more information.
 
   .. note::
     This feature does not support an upgrade from an earlier version of the NVIDIA GPU Operator or switching from ClusterPolicy to the NVIDIA Driver CRD.
@@ -1393,11 +1411,11 @@ Known Limitations
 * Using NVIDIA vGPU on bare metal nodes and NVSwitch is not supported.
 * All worker nodes in the Kubernetes cluster must run the same operating system version to use the NVIDIA GPU Driver container.
   Alternatively, if you pre-install the NVIDIA GPU Driver on the nodes, then you can run different operating systems.
-  The technical preview feature that provides :doc:`gpu-driver-configuration` is also an alternative.
+  The technical preview feature that provides :doc:`nvidia-driver-configuration` is also an alternative.
 * NVIDIA GPUDirect Storage (GDS) is not supported with secure boot enabled systems.
 * The NVIDIA GPU Operator can only be used to deploy a single NVIDIA GPU Driver type and version.
   The NVIDIA vGPU and Data Center GPU Driver cannot be used within the same cluster.
-  The technical preview feature that provides :doc:`gpu-driver-configuration` is an alternative.
+  The technical preview feature that provides :doc:`nvidia-driver-configuration` is an alternative.
 * The ``nouveau`` driver must be blacklisted when using NVIDIA vGPU.
   Otherwise the driver fails to initialize the GPU with the error ``Failed to enable MSI-X`` in the system journal logs.
   Additionally, all GPU Operator pods become stuck in the ``Init`` state.
@@ -1547,13 +1565,13 @@ Known Limitations
   argument so that the default value, ``false``, is used.
 * All worker nodes in the Kubernetes cluster must run the same operating system version to use the NVIDIA GPU Driver container.
   Alternatively, if you pre-install the NVIDIA GPU Driver on the nodes, then you can run different operating systems.
-  The technical preview feature that provides :doc:`gpu-driver-configuration` is also an alternative.
+  The technical preview feature that provides :doc:`nvidia-driver-configuration` is also an alternative.
 * NVIDIA GPUDirect Storage (GDS) is not supported with secure boot enabled systems.
 * Driver Toolkit images are broken with Red Hat OpenShift version ``4.11.12`` and require cluster-level entitlements to be enabled
   in this case for the driver installation to succeed.
 * The NVIDIA GPU Operator can only be used to deploy a single NVIDIA GPU Driver type and version.
   The NVIDIA vGPU and Data Center GPU Driver cannot be used within the same cluster.
-  The technical preview feature that provides :doc:`gpu-driver-configuration` is an alternative.
+  The technical preview feature that provides :doc:`nvidia-driver-configuration` is an alternative.
 * The ``nouveau`` driver must be blacklisted when using NVIDIA vGPU.
   Otherwise the driver fails to initialize the GPU with the error ``Failed to enable MSI-X`` in the system journal logs.
   Additionally, all GPU Operator pods become stuck in the ``Init`` state.
@@ -1662,13 +1680,13 @@ Known Limitations
   argument so that the default value, ``false``, is used.
 * All worker nodes in the Kubernetes cluster must run the same operating system version to use the NVIDIA GPU Driver container.
   Alternatively, if you pre-install the NVIDIA GPU Driver on the nodes, then you can run different operating systems.
-  The technical preview feature that provides :doc:`gpu-driver-configuration` is also an alternative.
+  The technical preview feature that provides :doc:`nvidia-driver-configuration` is also an alternative.
 * NVIDIA GPUDirect Storage (GDS) is not supported with secure boot enabled systems.
 * Driver Toolkit images are broken with Red Hat OpenShift version ``4.11.12`` and require cluster-level entitlements to be enabled
   in this case for the driver installation to succeed.
 * The NVIDIA GPU Operator can only be used to deploy a single NVIDIA GPU Driver type and version.
   The NVIDIA vGPU and Data Center GPU Driver cannot be used within the same cluster.
-  The technical preview feature that provides :doc:`gpu-driver-configuration` is an alternative.
+  The technical preview feature that provides :doc:`nvidia-driver-configuration` is an alternative.
 * The ``nouveau`` driver must be blacklisted when using NVIDIA vGPU.
   Otherwise the driver fails to initialize the GPU with the error ``Failed to enable MSI-X`` in the system journal logs.
   Additionally, all GPU Operator pods become stuck in the ``Init`` state.
@@ -1709,7 +1727,7 @@ New Features
 
   - Refer to :ref:`gpu-operator-helm-chart-options` for information about setting
     ``useOpenKernelModules`` if you manage the driver containers with the NVIDIA cluster policy custom resource definition.
-  - Refer to :doc:`gpu-driver-configuration` for information about setting ``spec.useOpenKernelModules``
+  - Refer to :doc:`nvidia-driver-configuration` for information about setting ``spec.useOpenKernelModules``
     if you manage the driver containers with the technology preview NVIDIA driver custom resource.
 
 * Includes these software component versions:
@@ -1811,13 +1829,13 @@ Known Limitations
   argument so that the default value, ``false``, is used.
 * All worker nodes in the Kubernetes cluster must run the same operating system version to use the NVIDIA GPU Driver container.
   Alternatively, if you pre-install the NVIDIA GPU Driver on the nodes, then you can run different operating systems.
-  The technical preview feature that provides :doc:`gpu-driver-configuration` is also an alternative.
+  The technical preview feature that provides :doc:`nvidia-driver-configuration` is also an alternative.
 * NVIDIA GPUDirect Storage (GDS) is not supported with secure boot enabled systems.
 * Driver Toolkit images are broken with Red Hat OpenShift version ``4.11.12`` and require cluster-level entitlements to be enabled
   in this case for the driver installation to succeed.
 * The NVIDIA GPU Operator can only be used to deploy a single NVIDIA GPU Driver type and version.
   The NVIDIA vGPU and Data Center GPU Driver cannot be used within the same cluster.
-  The technical preview feature that provides :doc:`gpu-driver-configuration` is an alternative.
+  The technical preview feature that provides :doc:`nvidia-driver-configuration` is an alternative.
 * The ``nouveau`` driver must be blacklisted when using NVIDIA vGPU.
   Otherwise the driver fails to initialize the GPU with the error ``Failed to enable MSI-X`` in the system journal logs.
   Additionally, all GPU Operator pods become stuck in the ``Init`` state.
@@ -1837,7 +1855,7 @@ New Features
   running multiple GPU driver types and versions on the same cluster and adds
   support for multiple operating system versions.
   This feature is a technology preview.
-  Refer to :doc:`gpu-driver-configuration` for more information.
+  Refer to :doc:`nvidia-driver-configuration` for more information.
 
 * Added support for additional Linux kernel variants for precompiled driver containers.
 
@@ -1908,13 +1926,13 @@ Known Limitations
   argument so that the default value, ``false``, is used.
 * All worker nodes in the Kubernetes cluster must run the same operating system version to use the NVIDIA GPU Driver container.
   Alternatively, if you pre-install the NVIDIA GPU Driver on the nodes, then you can run different operating systems.
-  The technical preview feature that provides :doc:`gpu-driver-configuration` is also an alternative.
+  The technical preview feature that provides :doc:`nvidia-driver-configuration` is also an alternative.
 * NVIDIA GPUDirect Storage (GDS) is not supported with secure boot enabled systems.
 * Driver Toolkit images are broken with Red Hat OpenShift version ``4.11.12`` and require cluster-level entitlements to be enabled
   in this case for the driver installation to succeed.
 * The NVIDIA GPU Operator can only be used to deploy a single NVIDIA GPU Driver type and version.
   The NVIDIA vGPU and Data Center GPU Driver cannot be used within the same cluster.
-  The technical preview feature that provides :doc:`gpu-driver-configuration` is an alternative.
+  The technical preview feature that provides :doc:`nvidia-driver-configuration` is an alternative.
 * The ``nouveau`` driver must be blacklisted when using NVIDIA vGPU.
   Otherwise the driver fails to initialize the GPU with the error ``Failed to enable MSI-X`` in the system journal logs.
   Additionally, all GPU Operator pods become stuck in the ``Init`` state.

--- a/repo.toml
+++ b/repo.toml
@@ -182,6 +182,7 @@ sphinx_exclude_patterns = [
   "life-cycle-policy.rst",
 ]
 redirects = [
+  { path="gpu-driver-configuration.html", target="nvidia-driver-configuration.html" },
   { path="openshift/introduction.html", project="openshift", target="introduction.html" },
   { path="openshift/time-slicing-gpus-in-openshift.html", project="openshift", target="time-slicing-gpus-in-openshift.html" },
   { path="openshift/enable-gpu-monitoring-dashboard.html", project="openshift", target="enable-gpu-monitoring-dashboard.html" },


### PR DESCRIPTION
Updates:

- [Release notes](https://nvidia.github.io/cloud-native-docs/review/pr-478/gpu-operator/latest/release-notes.html#new-features), ctrl+F "NVIDIA driver CRD" for the additional enhancements.
- min [containerd](https://nvidia.github.io/cloud-native-docs/review/pr-478/gpu-operator/latest/release-notes.html#new-features) changed to 2.0
- revised GPU driver to NVIDIA driver on the [dedicated page](https://nvidia.github.io/cloud-native-docs/review/pr-478/gpu-operator/latest/nvidia-driver-configuration.html).
- added AKS back to the [cloud service providers](https://nvidia.github.io/cloud-native-docs/review/pr-478/gpu-operator/latest/platform-support.html#cloud-service-providers) table.
- bumped Canonical MicroK8s to 1.36 in the [distributions table](https://nvidia.github.io/cloud-native-docs/review/pr-478/gpu-operator/latest/platform-support.html#bare-metal).
- Added a few sentence about [partitionN](https://nvidia.github.io/cloud-native-docs/review/pr-478/gpu-operator/latest/gpu-operator-kubevirt-dra.html#verify-dra-resources) on the KubeVirt w/ DRA page