### PR TITLE
docs: document Red Hat-provided precompiled driver images for OpenShift

### DIFF
--- a/openshift/gpu-operator-with-precompiled-drivers.rst
+++ b/openshift/gpu-operator-with-precompiled-drivers.rst
@@ -9,9 +9,6 @@
 Precompiled Drivers for the NVIDIA GPU Operator for RHCOS
 ###############################################################
 
-.. note:: Technology Preview features are not supported in production environments and are not functionally complete. Technology Preview features provide early access to upcoming product features, enabling customers to test functionality and provide feedback during the development process. These releases may not have any documentation, and testing is limited.
-
-
 ***********************************
 About Precompiled Driver Containers
 ***********************************
@@ -20,11 +17,30 @@ By default, NVIDIA GPU drivers are built on the cluster nodes when you deploy th
 Driver compilation and packaging is done on every Kubernetes node, leading to bursts of compute demand, waste of resources, and long provisioning times.
 In contrast, using container images with precompiled drivers makes the drivers immediately available on all nodes, resulting in faster provisioning and cost savings in public cloud deployments.
 
+*******************************************
+Red Hat-Provided Precompiled Driver Images
+*******************************************
+
+Red Hat publishes official precompiled NVIDIA GPU driver images for Red Hat OpenShift at ``registry.redhat.io/nvidia`` under the ``gpu-driver-rhel9`` image name. You can use these images to avoid building and hosting your own custom precompiled driver image for common deployments.
+
+The registry hosts multiple tags for the driver image, including fixed tags for specific driver releases, such as ``580.65.06``, and a floating major-version tag, such as ``580``.  The floating major-version tag always refers to the latest driver release within that major branch. Pinning to the major-version tag enables your cluster to use new driver releases automatically within the same major version as they are published. Pinning to a fixed version tag keeps the driver version constant until you change it.
+
+To use a Red Hat-provided precompiled driver image, set the ``driver`` fields of the ``ClusterPolicy`` resource as shown in the following example:
+
+.. code-block:: json
+
+   "driver": {
+     "usePrecompiled": true,
+     "repository": "registry.redhat.io/nvidia",
+     "image": "gpu-driver-rhel9",
+     "version": "580"
+   }
+
 ***********************************
 Limitations and Restrictions
 ***********************************
 
-* NVIDIA does not provide precompiled driver images for Red Hat OpenShift. Such images have to be custom built and hosted in a public or private image registry.
+* Red Hat provides official precompiled driver images for Red Hat OpenShift at ``registry.redhat.io/nvidia``. Custom precompiled driver images built from other sources, such as the NVIDIA community driver container repository, must be custom built and hosted in a public or private image registry.
 
 * NVIDIA provides limited support for custom driver container images.
 
@@ -84,7 +100,7 @@ Perform the following steps to build a custom driver image for use with Red Hat 
 
    .. code-block:: console
 
-      export OPENSHIFT_VERSION="4.18.24"
+      export OPENSHIFT_VERSION="4.22.0"
       export TARGET_ARCH="x86_64"
 
 #. Determine the Driver Toolkit (DTK) image for your target Red Hat OpenShift version and architecture:
@@ -115,7 +131,7 @@ Perform the following steps to build a custom driver image for use with Red Hat 
       export CUDA_DIST=ubi${RHEL_MAJOR}
       export DRIVER_EPOCH=1
       export DRIVER_VERSION=525.105.17
-      export OS_TAG=rhcos4.18
+      export OS_TAG=rhcos4.22
 
 #. Build and push the image:
 
@@ -231,7 +247,7 @@ Using the CLI
    .. code-block:: console
 
       NAME                                                            READY   STATUS    RESTARTS   AGE
-      nvidia-driver-daemonset-<kernel-version>-rhcos4.18-mlpd4   1/1     Running   0          44s
+      nvidia-driver-daemonset-<kernel-version>-rhcos4.22-mlpd4   1/1     Running   0          44s
 
    Ensure that the pod names include the Linux kernel version number in place of ``<kernel-version>``.
 


### PR DESCRIPTION
**Summary**

Documents the new Red Hat-published precompiled NVIDIA GPU driver images for OpenShift and refreshes stale version references in the precompiled-driver guide.

**What changed**

- Added a new "Red Hat-Provided Precompiled Driver Images" section describing the official precompiled driver images Red Hat publishes at registry.redhat.io/nvidia (image gpu-driver-rhel9), including:
- The tagging scheme (fixed tags like 580.65.06 vs. the floating major-version tag 580).
- A ClusterPolicy driver field example showing how to consume these images (usePrecompiled: true, repository, image, version).
- Updated the "Limitations and Restrictions" section: previously stated NVIDIA doesn't provide precompiled images for OpenShift; now clarifies Red Hat provides official ones, while custom images from other sources (e.g., the NVIDIA community driver container repository) still require self-hosting.
- Bumped stale example versions in the custom driver image build walkthrough:
- OPENSHIFT_VERSION example: 4.18.24 → 4.22.0
- OS_TAG example: rhcos4.18 → rhcos4.22
- Sample pod name in the CLI verification output: rhcos4.18 → rhcos4.22

**Why**

Red Hat now officially publishes precompiled GPU driver images for OpenShift, removing the previous requirement to build and host a custom image for common deployments. This page previously said no such images existed, so it needed correcting; the version bumps also keep the walkthrough aligned with a currently supported OpenShift release.