### PR TITLE
docs: add Kubernetes 1.37 support for GPU Operator 26.7.0

### DIFF
--- a/.codespell_exclude_lines.txt
+++ b/.codespell_exclude_lines.txt
@@ -46,3 +46,4 @@ Refer to the MKE product documentation for information about working with MKE.
          $ cat <<EOF > nvidia-container-microshift.te
          $ checkmodule -m -M -o nvidia-container-microshift.mod nvidia-container-microshift.te
       2023/06/22 14:25:38 Retreiving plugins.
+* Restored Azure Kubernetes Service (AKS) to the :ref:`cloud service providers <cloud-service-providers>` table.

--- a/gpu-operator/platform-support.rst
+++ b/gpu-operator/platform-support.rst
@@ -325,33 +325,33 @@ Bare Metal / Virtual Machines with GPU Passthrough and NVIDIA vGPU
         | NKP
 
     * - Ubuntu 26.04 LTS
-      - 1.33---1.36
+      - 1.33---1.37
       -
       -
-      - 1.33---1.36
-      - 1.33---1.36
-      - 1.33---1.36
-      - 1.33---1.36
+      - 1.33---1.37
+      - 1.33---1.37
+      - 1.33---1.37
+      - 1.33---1.37
       - 2.17
 
     * - Ubuntu 24.04 LTS
-      - 1.32---1.36
+      - 1.32---1.37
       -
       -
-      - 1.33---1.36
-      - 1.33---1.36
-      - 1.33---1.36
-      - 1.33---1.36
+      - 1.33---1.37
+      - 1.33---1.37
+      - 1.33---1.37
+      - 1.33---1.37
       - 2.17
 
     * - Ubuntu 22.04 LTS |fn2|_
-      - 1.33---1.36
+      - 1.33---1.37
       -
-      - 1.33---1.36
-      - 1.33---1.36
-      - 1.33---1.36
-      - 1.33---1.36
-      - 1.33---1.36
+      - 1.33---1.37
+      - 1.33---1.37
+      - 1.33---1.37
+      - 1.33---1.37
+      - 1.33---1.37
       - 2.15 2.16 2.17
 
     * - Red Hat Core OS
@@ -367,10 +367,10 @@ Bare Metal / Virtual Machines with GPU Passthrough and NVIDIA vGPU
     * - | Red Hat
         | Enterprise
         | Linux 10.0, 10.1, 10.2
-      - 1.33---1.36
+      - 1.33---1.37
       -
       -
-      - 1.33---1.36
+      - 1.33---1.37
       -
       -
       -
@@ -379,10 +379,10 @@ Bare Metal / Virtual Machines with GPU Passthrough and NVIDIA vGPU
     * - | Red Hat
         | Enterprise
         | Linux 9.2, 9.4, 9.6, 9.7, 9.8 |fn3|_
-      - 1.33---1.36
+      - 1.33---1.37
       -
       -
-      - 1.33---1.36
+      - 1.33---1.37
       -
       -
       -
@@ -392,17 +392,17 @@ Bare Metal / Virtual Machines with GPU Passthrough and NVIDIA vGPU
         | Enterprise
         | Linux 8.8,
         | 8.10
-      - 1.33---1.36
+      - 1.33---1.37
       -
       -
-      - 1.33---1.36
+      - 1.33---1.37
       -
       -
       -
       - 2.15, 2.16, 2.17
 
     * - Rocky Linux 10.1
-      - 1.33---1.36
+      - 1.33---1.37
       -
       -
       -
@@ -412,7 +412,7 @@ Bare Metal / Virtual Machines with GPU Passthrough and NVIDIA vGPU
       -
 
     * - Rocky Linux 9.7
-      - 1.33---1.36
+      - 1.33---1.37
       -
       -
       -
@@ -422,7 +422,7 @@ Bare Metal / Virtual Machines with GPU Passthrough and NVIDIA vGPU
       -
 
     * - Rocky Linux 8.10
-      - 1.33---1.36
+      - 1.33---1.37
       -
       -
       -
@@ -487,19 +487,19 @@ Cloud Service Providers
         | Kubernetes Service
 
     * - Ubuntu 26.04 LTS
-      - 1.33---1.36
-      - 1.33---1.36
-      - 1.33---1.36
+      - 1.33---1.37
+      - 1.33---1.37
+      - 1.33---1.37
 
     * - Ubuntu 24.04 LTS
-      - 1.33---1.36
-      - 1.33---1.36
-      - 1.33---1.36
+      - 1.33---1.37
+      - 1.33---1.37
+      - 1.33---1.37
 
     * - Ubuntu 22.04 LTS
-      - 1.33---1.36
-      - 1.33---1.36
-      - 1.33---1.36
+      - 1.33---1.37
+      - 1.33---1.37
+      - 1.33---1.37
 
 .. _supported-precompiled-drivers:
 
@@ -604,9 +604,9 @@ Operating System    Kubernetes           KubeVirt              OpenShift Virtual
 \                   \             | GPU           vGPU         | GPU            vGPU
                                   | Passthrough                | Passthrough
 ================    ===========   =============   =========    =============    ===========
-Ubuntu 26.04 LTS    1.33---1.36   0.36+
-Ubuntu 24.04 LTS    1.33---1.36   0.36+
-Ubuntu 22.04 LTS    1.33---1.36   0.36+           0.59.1+
+Ubuntu 26.04 LTS    1.33---1.37   0.36+
+Ubuntu 24.04 LTS    1.33---1.37   0.36+
+Ubuntu 22.04 LTS    1.33---1.37   0.36+           0.59.1+
 Red Hat Core OS                                                4.18---4.22      4.18---4.22
 ================    ===========   =============   =========    =============    ===========
 

--- a/gpu-operator/release-notes.rst
+++ b/gpu-operator/release-notes.rst
@@ -55,7 +55,7 @@ New Features
   - NVIDIA vGPU Device Manager v0.5.0
   - NVIDIA KubeVirt GPU Device Plugin v1.6.0
   - NVIDIA GDS Driver v2.29.4
-  - NVIDIA Confidental Computing Manager for Kubernetes v0.4.3
+  - NVIDIA Confidential Computing Manager for Kubernetes v0.4.3
   - NVIDIA GDRCopy Driver v2.6
   - NVIDIA Kata Sandbox Device Plugin v0.0.5
 
@@ -200,6 +200,7 @@ Post-Release Documentation Updates
 * Restored Azure Kubernetes Service (AKS) to the :ref:`cloud service providers <cloud-service-providers>` table.
 * Added support for Kubernetes 1.36 for Canonical MicroK8s to the :ref:`bare-metal` table.
 * Added a brief explanation of the ``partitionN`` attribute to the :ref:`gpu-operator-kubevirt-dra` page.
+* Added support for Kubernetes 1.37 to the :ref:`bare-metal`, :ref:`cloud service providers <cloud-service-providers>`, and KubeVirt and OpenShift Virtualization tables.
 
 
 ----


### PR DESCRIPTION
## Summary

Closes #482.

Raises the upper bound of the validated Kubernetes range from 1.36 to 1.37 in every version cell of `gpu-operator/platform-support.rst` — the bare metal / vGPU table, the cloud service providers table, and the KubeVirt / OpenShift Virtualization table — and records the change under **26.7.0 > Post-Release Documentation Updates**.

Lower bounds are unchanged per the issue owner: `1.33---1.37`, and `1.32---1.37` for Ubuntu 24.04.

Two unrelated pre-existing `codespell` failures in `release-notes.rst` blocked the commit hook, so this branch also fixes `Confidental` -> `Confidential` and adds the AKS post-release line to `.codespell_exclude_lines.txt`.


Link to Devin session: https://nvidia-cloud.devinenterprise.com/sessions/0a6e977b1e35401f980f2d35626e5487
Open in Devin Desktop: https://nvidia-cloud.devinenterprise.com/desktop/session/0a6e977b1e35401f980f2d35626e5487?variant=devin
Requested by: @mikemckiernan