### PR TITLE
docs: update GPU Operator minimum Kubernetes version

### DIFF
--- a/gpu-operator/platform-support.rst
+++ b/gpu-operator/platform-support.rst
@@ -335,7 +335,7 @@ Bare Metal / Virtual Machines with GPU Passthrough and NVIDIA vGPU
       - 2.17
 
     * - Ubuntu 24.04 LTS
-      - 1.32---1.37
+      - 1.33---1.37
       -
       -
       - 1.33---1.37


### PR DESCRIPTION
## Summary

- Update the lower supported Kubernetes version for Ubuntu 24.04 from 1.32 to 1.33.
- Preserve the Kubernetes 1.32 references in the historical release notes.

## Testing

- `git diff --check`
- Full documentation build not run; it will be run separately.